### PR TITLE
Fix schema differences

### DIFF
--- a/miner/app/src/compute_horde_miner/miner/miner_consumer/layer_utils.py
+++ b/miner/app/src/compute_horde_miner/miner/miner_consumer/layer_utils.py
@@ -47,7 +47,7 @@ class ExecutorFinished(pydantic.BaseModel):
 
 class ExecutorFailed(pydantic.BaseModel):
     job_uuid: str
-    docker_process_exit_status: int
+    docker_process_exit_status: int | None
     docker_process_stdout: str
     docker_process_stderr: str
 
@@ -183,7 +183,7 @@ class ExecutorInterfaceMixin(BaseMixin):
         )
 
     async def send_executor_failed(self, job_uuid: str, executor_token: str, stdout: str, stderr: str,
-                                   exit_status: int):
+                                   exit_status: int | None):
         group_name = ValidatorInterfaceMixin.group_name(executor_token)
         await self.channel_layer.group_send(
             group_name,


### PR DESCRIPTION
This PR fixes 2 instances of mismatch that are occurring:

1. `docker_process_exit_status` field being `None` on timeout, failing validation for `ExecutorFailed` on miner's executor->validator layer
2. Structure of `JobStatusUpdate.miner_response` being different on `status=rejected` failing validation on facilitator