### PR TITLE
Use docker cli image as base for runner images

### DIFF
--- a/miner/envs/runner-staging/Dockerfile
+++ b/miner/envs/runner-staging/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:22.04
-EXPOSE 80
-RUN apt-get update && apt-get install -y docker.io docker-compose
+FROM docker:26-cli
 WORKDIR /root
 COPY data/docker-compose.yml docker-compose.yml
-ENTRYPOINT ["docker-compose", "up"]
+ENTRYPOINT ["docker", "compose", "up"]

--- a/miner/envs/runner/Dockerfile
+++ b/miner/envs/runner/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:22.04
-EXPOSE 80
-RUN apt-get update && apt-get install -y docker.io docker-compose
+FROM docker:26-cli
 WORKDIR /root
 COPY data/docker-compose.yml docker-compose.yml
-ENTRYPOINT ["docker-compose", "up"]
+ENTRYPOINT ["docker", "compose", "up"]

--- a/miner/envs/runner/build-image.sh
+++ b/miner/envs/runner/build-image.sh
@@ -3,4 +3,4 @@
 ( cd nginx && ./build-image.sh )
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-miner-runner:v0-latest"
-docker build -t $IMAGE_NAME .
+docker build --platform=linux/amd64 -t $IMAGE_NAME .

--- a/validator/envs/runner-staging/Dockerfile
+++ b/validator/envs/runner-staging/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:22.04
-EXPOSE 80
-RUN apt-get update && apt-get install -y docker.io docker-compose
+FROM docker:26-cli
 WORKDIR /root/validator
 COPY data/docker-compose.yml docker-compose.yml
 COPY entrypoint.sh /entrypoint.sh

--- a/validator/envs/runner-staging/entrypoint.sh
+++ b/validator/envs/runner-staging/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -eu
 
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 
 while true
 do
-    docker-compose logs -f
+    docker compose logs -f
     echo 'All containers died'
     sleep 10
 done

--- a/validator/envs/runner/Dockerfile
+++ b/validator/envs/runner/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:22.04
-EXPOSE 80
-RUN apt-get update && apt-get install -y docker.io docker-compose
+FROM docker:26-cli
 WORKDIR /root/validator
 COPY data/docker-compose.yml docker-compose.yml
 COPY entrypoint.sh /entrypoint.sh

--- a/validator/envs/runner/build-image.sh
+++ b/validator/envs/runner/build-image.sh
@@ -2,4 +2,4 @@
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-validator-runner:v0-latest"
 rsync -avzP ../../nginx/config_helpers data/nginx/
-docker build -t $IMAGE_NAME .
+docker build --platform=linux/amd64 -t $IMAGE_NAME .

--- a/validator/envs/runner/entrypoint.sh
+++ b/validator/envs/runner/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -eu
 
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 
 while true
 do
-    docker-compose logs -f
+    docker compose logs -f
     echo 'All containers died'
     sleep 10
 done


### PR DESCRIPTION
`docker:26-cli` image includes docker cli v26 and compose v2. Previously, docker v24 & compose v1 was conflicting with host's docker, if the host docker version was >=26.