### PR TITLE
Docker image LRU eviction in miner (executor)

### DIFF
--- a/executor/app/src/compute_horde_executor/executor/management/commands/run_executor.py
+++ b/executor/app/src/compute_horde_executor/executor/management/commands/run_executor.py
@@ -40,7 +40,6 @@ TRUNCATED_RESPONSE_PREFIX_LEN = 100
 TRUNCATED_RESPONSE_SUFFIX_LEN = 100
 INPUT_VOLUME_UNPACK_TIMEOUT_SECONDS = 300
 CVE_2022_0492_IMAGE = "us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest"
-DOCKER_BASE_IMAGES_TO_KEEP = {"python", "ubuntu", "debian", "alpine", "backenddevelopersltd/compute-horde-job"}
 
 
 class RunConfigManager:
@@ -320,24 +319,6 @@ class JobRunner:
         )
         await process.wait()
         self.temp_dir.rmdir()
-
-        image_names = [self.initial_job_request.base_docker_image_name]
-        if self.full_job_request:
-            image_names.append(self.full_job_request.docker_image_name)
-        for image_name in image_names:
-            if not image_name:
-                continue
-            image_repo, _, _ = self.initial_job_request.base_docker_image_name.partition(":")
-            if image_repo not in DOCKER_BASE_IMAGES_TO_KEEP:
-                process = await asyncio.create_subprocess_exec(
-                    'docker',
-                    'rmi',
-                    image_name,
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                )
-                await process.wait()
-
 
     async def _unpack_volume(self, job_request: V0JobRequest):
         assert str(self.volume_mount_dir) not in {'~', '/'}

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -123,7 +123,6 @@ services:
       "--keep", "^backenddevelopersltd/compute-horde-job:v0-latest",
       "--keep", "^us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest",
     ]
-    pull_policy: always
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -115,9 +115,12 @@ services:
       "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
       "--keep", "^redis:6-alpine",
       "--keep", "^postgres:14.0-alpine",
+      "--keep", "^containrrr/watchtower",
+      "--keep", "^stephanmisc/docuum",
+      "--keep", "^backenddevelopersltd/compute-horde-miner-runner-staging:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-staging:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
-      "--keep", "^backenddevelopersltd/compute-horde-job",
+      "--keep", "^backenddevelopersltd/compute-horde-job:v0-latest",
       "--keep", "^us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest",
     ]
     pull_policy: always

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -111,7 +111,14 @@ services:
 
   docuum:
     image: stephanmisc/docuum
-    command: --threshold ${DOCKER_STORAGE_THRESHOLD:-50 GB}
+    command: [
+      "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
+      "--keep", "^redis:6-alpine",
+      "--keep", "^postgres:14.0-alpine",
+      "--keep", "^backenddevelopersltd/compute-horde-miner-staging:v0-latest",
+      "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
+      "--keep", "^backenddevelopersltd/compute-horde-job",
+    ]
     pull_policy: always
     init: true
     restart: unless-stopped

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -110,13 +110,13 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   docuum:
-    image: stephanmisc/docuum
+    image: stephanmisc/docuum:0.23.1
     command: [
       "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
       "--keep", "^redis:6-alpine",
       "--keep", "^postgres:14.0-alpine",
       "--keep", "^containrrr/watchtower",
-      "--keep", "^stephanmisc/docuum",
+      "--keep", "^stephanmisc/docuum:0.23.1",
       "--keep", "^backenddevelopersltd/compute-horde-miner-runner-staging:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-staging:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
@@ -132,8 +132,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     logging:
       <<: *logging
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
 
 volumes:
   redis:

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       "--keep", "^backenddevelopersltd/compute-horde-miner-staging:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-job",
+      "--keep", "^us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest",
     ]
     pull_policy: always
     init: true

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -109,7 +109,23 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
+  docuum:
+    image: stephanmisc/docuum
+    command: --threshold ${DOCKER_STORAGE_THRESHOLD:-50 GB}
+    pull_policy: always
+    init: true
+    restart: unless-stopped
+    env_file: ./.env
+    volumes:
+      - docuum:/root
+      - /var/run/docker.sock:/var/run/docker.sock
+    logging:
+      <<: *logging
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
 volumes:
   redis:
   db:
   static:
+  docuum:

--- a/miner/envs/runner-staging/data/docker-compose.yml
+++ b/miner/envs/runner-staging/data/docker-compose.yml
@@ -125,7 +125,6 @@ services:
     ]
     init: true
     restart: unless-stopped
-    env_file: ./.env
     volumes:
       - docuum:/root
       - /var/run/docker.sock:/var/run/docker.sock

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -110,13 +110,13 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   docuum:
-    image: stephanmisc/docuum
+    image: stephanmisc/docuum:0.23.1
     command: [
       "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
       "--keep", "^redis:6-alpine",
       "--keep", "^postgres:14.0-alpine",
       "--keep", "^containrrr/watchtower",
-      "--keep", "^stephanmisc/docuum",
+      "--keep", "^stephanmisc/docuum:0.23.1",
       "--keep", "^backenddevelopersltd/compute-horde-miner-runner:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
@@ -132,8 +132,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     logging:
       <<: *logging
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
 
 volumes:
   redis:

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -123,7 +123,6 @@ services:
       "--keep", "^backenddevelopersltd/compute-horde-job:v0-latest",
       "--keep", "^us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest",
     ]
-    pull_policy: always
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       "--keep", "^backenddevelopersltd/compute-horde-miner:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-job",
+      "--keep", "^us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest",
     ]
     pull_policy: always
     init: true

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -115,9 +115,12 @@ services:
       "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
       "--keep", "^redis:6-alpine",
       "--keep", "^postgres:14.0-alpine",
+      "--keep", "^containrrr/watchtower",
+      "--keep", "^stephanmisc/docuum",
+      "--keep", "^backenddevelopersltd/compute-horde-miner-runner:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner:v0-latest",
       "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
-      "--keep", "^backenddevelopersltd/compute-horde-job",
+      "--keep", "^backenddevelopersltd/compute-horde-job:v0-latest",
       "--keep", "^us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest",
     ]
     pull_policy: always

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -109,7 +109,23 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
+  docuum:
+    image: stephanmisc/docuum
+    command: --threshold ${DOCKER_STORAGE_THRESHOLD:-50 GB}
+    pull_policy: always
+    init: true
+    restart: unless-stopped
+    env_file: ./.env
+    volumes:
+      - docuum:/root
+      - /var/run/docker.sock:/var/run/docker.sock
+    logging:
+      <<: *logging
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
 volumes:
   redis:
   db:
   static:
+  docuum:

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -111,7 +111,14 @@ services:
 
   docuum:
     image: stephanmisc/docuum
-    command: --threshold ${DOCKER_STORAGE_THRESHOLD:-50 GB}
+    command: [
+      "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
+      "--keep", "^redis:6-alpine",
+      "--keep", "^postgres:14.0-alpine",
+      "--keep", "^backenddevelopersltd/compute-horde-miner:v0-latest",
+      "--keep", "^backenddevelopersltd/compute-horde-miner-nginx:v0-latest",
+      "--keep", "^backenddevelopersltd/compute-horde-job",
+    ]
     pull_policy: always
     init: true
     restart: unless-stopped

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -125,7 +125,6 @@ services:
     ]
     init: true
     restart: unless-stopped
-    env_file: ./.env
     volumes:
       - docuum:/root
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
- Remove the logic of docker image clean-up after job execution.
- `docuum` keeps track of docker events. When docker image storage crosses a threshold it evicts the least recently used images.
- Image storage threshold can be configured with the `DOCKER_STORAGE_THRESHOLD` environment variable.
- A default threshold of `50 GB` is arbitrarily chosen.