### PR TITLE
Handle miner connection refusal in validator

### DIFF
--- a/compute_horde/compute_horde/miner_client/base.py
+++ b/compute_horde/compute_horde/miner_client/base.py
@@ -79,11 +79,14 @@ class AbstractMinerClient(abc.ABC):
                     sleep_time = self.sleep_time()
                     logger.info(f'Retrying connection to miner {self.miner_name} in {sleep_time:0.2f}')
                     await asyncio.sleep(sleep_time)
-                self.debounce_counter += 1
                 self.ws = await self._connect()
                 self.read_messages_task = self.loop.create_task(self.read_messages())
+                if self.debounce_counter:
+                    logger.info(f'Connected to miner {self.miner_name} after {self.debounce_counter + 1} attempts')
+                    self.debounce_counter = 0
                 return
             except (websockets.WebSocketException, OSError) as ex:
+                self.debounce_counter += 1
                 logger.info(f'Could not connect to miner {self.miner_name}: {str(ex)}')
 
     def sleep_time(self):

--- a/compute_horde/compute_horde/miner_client/base.py
+++ b/compute_horde/compute_horde/miner_client/base.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import logging
 import random
+import time
 
 import websockets
 
@@ -10,10 +11,15 @@ from compute_horde.base_requests import BaseRequest, ValidationError
 logger = logging.getLogger(__name__)
 
 
+class MinerConnectionError(Exception):
+    pass
+
+
 class AbstractMinerClient(abc.ABC):
 
     def __init__(self, loop: asyncio.AbstractEventLoop, miner_name: str):
         self.debounce_counter = 0
+        self.max_debounce_count: int | None = 5  # set to None for unlimited debounce
         self.loop = loop
         self.miner_name = miner_name
         self.ws: websockets.WebSocketClientProtocol | None = None
@@ -60,8 +66,15 @@ class AbstractMinerClient(abc.ABC):
         return await websockets.connect(self.miner_url())
 
     async def await_connect(self):
+        start_time = time.time()
         while True:
             try:
+                if self.max_debounce_count is not None and self.debounce_counter > self.max_debounce_count:
+                    time_took = time.time() - start_time
+                    raise MinerConnectionError(
+                        f'Could not connect to miner {self.miner_name} after {self.max_debounce_count} tries'
+                        f' in {time_took:0.2f} seconds'
+                    )
                 if self.debounce_counter:
                     sleep_time = self.sleep_time()
                     logger.info(f'Retrying connection to miner {self.miner_name} in {sleep_time:0.2f}')


### PR DESCRIPTION
The validators/miners trying to connect a miner that is refusing the connection can lead to an infinite loop, because miner connection was retried forever (with exponential backoff). As a consequence, the status of the job is never reported in the facilitator.

This PR adds a max-retry limit of 5 for connecting to a miner. If the limit is exceeded, the job is considered failed and reported as such to the facilitator.

Previously on facilitator:
![image](https://github.com/backend-developers-ltd/ComputeHorde/assets/137923473/44eda418-fcdf-4dca-9bee-4dccba558ff0)

After this PR:
![image](https://github.com/backend-developers-ltd/ComputeHorde/assets/137923473/8f64fdb3-8309-4279-8c52-f0cb47ab4bfb)


**Note:** the `MinerConnectionError` exception is purposefully not handled in the executor, so that miners can notice fast if their executors cannot connect to their miners. This is often an issue with miner's configuration.