### PR TITLE
Add installer scripts for miner & validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ for miner in miners:
 
 # Running
 
-To quickly start a validator or miner, create an ubuntu server and execute the following command from your local machine (where you have your wallet files).
+To quickly start a validator or miner, create an Ubuntu Server and execute the following command from your local machine (where you have your wallet files).
 
 **Validator:**
 ```shell

--- a/README.md
+++ b/README.md
@@ -30,5 +30,20 @@ In February 2024 this will change - subnet will define more resource types andVa
 
 # Running
 
-Refer to [Miner runner README](miner/envs/runner/README.md) and to 
-[Validator runner README](validator/envs/runner/README.md)
+To quickly start a validator or miner, create an ubuntu server and execute the following command from your local machine (where you have your wallet files).
+
+**Validator:**
+```shell
+curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/install_validator.sh | bash -s - SSH_DESTINATION HOTKEY_PATH
+```
+
+**Miner:**
+```shell
+curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/install_miner.sh | bash -s - SSH_DESTINATION HOTKEY_PATH
+```
+
+Replace `SSH_DESTINATION` with your server's connection info (i.e. `username@1.2.3.4`)
+and `HOTKEY_PATH` with the path of your hotkey (i.e. `~/.bittensor/wallets/my-wallet/hotkeys/my-hotkey`).
+This script installs necessary tools in the server, copies the keys and starts the validator/miner with the corresponding runner and default config.
+
+If you want to change the default config, see [Validator runner README](validator/envs/runner/README.md) and [Miner runner README](miner/envs/runner/README.md) for details.

--- a/install_miner.sh
+++ b/install_miner.sh
@@ -95,8 +95,8 @@ services:
 ENDDOCKERCOMPOSE
 
 cat > .env <<ENDENV
-SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(25))')
-POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
+SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe(25))')
+POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')
 BITTENSOR_NETUID=12
 BITTENSOR_NETWORK=finney
 BITTENSOR_WALLET_NAME="$(. ~/tmpvars && echo "$WALLET_NAME")"

--- a/install_miner.sh
+++ b/install_miner.sh
@@ -3,16 +3,16 @@ set -euxo pipefail
 
 if [ $# -ne 2 ]
 then
-  echo >2 "USAGE: ./install_miner.sh SSH_DESTINATION HOTKEY_PATH"
+  >&2 echo "USAGE: ./install_miner.sh SSH_DESTINATION HOTKEY_PATH"
   exit 1
 fi
 
 SSH_DESTINATION="$1"
 LOCAL_HOTKEY_PATH=$(realpath "$2")
-LOCAL_COLDKEY_PUB_PATH=$(dirname $(dirname "$LOCAL_HOTKEY_PATH"))/coldkeypub.txt
+LOCAL_COLDKEY_PUB_PATH=$(dirname "$(dirname "$LOCAL_HOTKEY_PATH")")/coldkeypub.txt
 
-if [ ! -f $LOCAL_HOTKEY_PATH ]; then
-  echo "Given HOTKEY_PATH does not exist"
+if [ ! -f "$LOCAL_HOTKEY_PATH" ]; then
+  >&2 echo "Given HOTKEY_PATH does not exist"
   exit 1
 fi
 
@@ -28,12 +28,13 @@ set -euxo pipefail
 mkdir -p $REMOTE_HOTKEY_DIR
 cat > tmpvars <<ENDCAT
 HOTKEY_NAME="$(basename "$REMOTE_HOTKEY_PATH")"
-WALLET_NAME="$(basename $(dirname "$REMOTE_HOTKEY_DIR"))"
+WALLET_NAME="$(basename "$(dirname "$REMOTE_HOTKEY_DIR")")"
 ENDCAT
 ENDSSH
 scp "$LOCAL_HOTKEY_PATH" "$SSH_DESTINATION:$REMOTE_HOTKEY_PATH"
 scp "$LOCAL_COLDKEY_PUB_PATH" "$SSH_DESTINATION:$REMOTE_COLDKEY_PUB_PATH"
 
+# install necessary software in the server
 ssh "$SSH_DESTINATION" <<'ENDSSH'
 set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
@@ -98,13 +99,12 @@ SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(25))')
 POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
 BITTENSOR_NETUID=12
 BITTENSOR_NETWORK=finney
-BITTENSOR_WALLET_NAME=$(. ~/tmpvars && echo "$WALLET_NAME")
-BITTENSOR_WALLET_HOTKEY_NAME=$(. ~/tmpvars && echo "$HOTKEY_NAME")
+BITTENSOR_WALLET_NAME="$(. ~/tmpvars && echo "$WALLET_NAME")"
+BITTENSOR_WALLET_HOTKEY_NAME="$(. ~/tmpvars && echo "$HOTKEY_NAME")"
 HOST_WALLET_DIR=$HOME/.bittensor/wallets
 BITTENSOR_MINER_PORT=8000
 BITTENSOR_MINER_ADDRESS=auto
 PORT_FOR_EXECUTORS=8000
-# TODO:               vvvvvvvvvv - what should be the value here?
 ADDRESS_FOR_EXECUTORS=172.17.0.1
 ENDENV
 

--- a/install_miner.sh
+++ b/install_miner.sh
@@ -48,8 +48,24 @@ set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 # install docker
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc
+do
+  sudo apt-get remove $pkg || true
+done
+
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl docker.io docker-compose
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get install -y docker-ce docker-compose-plugin
 sudo usermod -aG docker $USER
 
 # install cuda
@@ -119,6 +135,6 @@ ENDENV
 docker pull backenddevelopersltd/compute-horde-executor:v0-latest
 docker pull backenddevelopersltd/compute-horde-miner:v0-latest
 docker pull backenddevelopersltd/compute-horde-job:v0-latest
-docker-compose up -d
+docker compose up -d
 
 ENDSSH

--- a/install_miner.sh
+++ b/install_miner.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ $# -ne 2 ]
+then
+  echo >2 "USAGE: ./install_miner.sh SSH_DESTINATION HOTKEY_PATH"
+  exit 1
+fi
+
+SSH_DESTINATION="$1"
+LOCAL_HOTKEY_PATH=$(realpath "$2")
+LOCAL_COLDKEY_PUB_PATH=$(dirname $(dirname "$LOCAL_HOTKEY_PATH"))/coldkeypub.txt
+
+if [ ! -f $LOCAL_HOTKEY_PATH ]; then
+  echo "Given HOTKEY_PATH does not exist"
+  exit 1
+fi
+
+# BSD (mac) `realpath` does not support `-s` or `--relative-to` :'(
+REMOTE_HOTKEY_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_HOTKEY_PATH', '$HOME'))")
+REMOTE_COLDKEY_PUB_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_COLDKEY_PUB_PATH', '$HOME'))")
+REMOTE_HOTKEY_DIR=$(dirname "$REMOTE_HOTKEY_PATH")
+
+# Copy the wallet files to the server
+ssh "$SSH_DESTINATION" <<ENDSSH
+set -euxo pipefail
+
+mkdir -p $REMOTE_HOTKEY_DIR
+cat > tmpvars <<ENDCAT
+HOTKEY_NAME="$(basename "$REMOTE_HOTKEY_PATH")"
+WALLET_NAME="$(basename $(dirname "$REMOTE_HOTKEY_DIR"))"
+ENDCAT
+ENDSSH
+scp "$LOCAL_HOTKEY_PATH" "$SSH_DESTINATION:$REMOTE_HOTKEY_PATH"
+scp "$LOCAL_COLDKEY_PUB_PATH" "$SSH_DESTINATION:$REMOTE_COLDKEY_PUB_PATH"
+
+ssh "$SSH_DESTINATION" <<'ENDSSH'
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# install docker
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl docker.io docker-compose
+sudo usermod -aG docker $USER
+
+# install cuda
+sudo apt-get install -y linux-headers-$(uname -r)
+DISTRIBUTION=$(. /etc/os-release; echo $ID$VERSION_ID | sed -e 's/\.//g')
+wget "https://developer.download.nvidia.com/compute/cuda/repos/$DISTRIBUTION/x86_64/cuda-keyring_1.0-1_all.deb"
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+sudo apt-get update
+sudo apt-get -y install cuda-drivers
+
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+  | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+  | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+  | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+ENDSSH
+
+# start a new ssh connection so that usermod changes are effective
+ssh "$SSH_DESTINATION" <<'ENDSSH'
+set -euxo pipefail
+mkdir ~/compute_horde_miner
+cd ~/compute_horde_miner
+
+cat > docker-compose.yml <<'ENDDOCKERCOMPOSE'
+version: '3.7'
+
+services:
+
+  miner-runner:
+    image: backenddevelopersltd/compute-horde-miner-runner:v0-latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - "$HOME/.bittensor/wallets:/root/.bittensor/wallets"
+      - ./.env:/root/.env
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 60 --cleanup --label-enable
+ENDDOCKERCOMPOSE
+
+cat > .env <<ENDENV
+SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(25))')
+POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
+BITTENSOR_NETUID=12
+BITTENSOR_NETWORK=finney
+BITTENSOR_WALLET_NAME=$(. ~/tmpvars && echo "$WALLET_NAME")
+BITTENSOR_WALLET_HOTKEY_NAME=$(. ~/tmpvars && echo "$HOTKEY_NAME")
+HOST_WALLET_DIR=$HOME/.bittensor/wallets
+BITTENSOR_MINER_PORT=8000
+BITTENSOR_MINER_ADDRESS=auto
+PORT_FOR_EXECUTORS=8000
+# TODO:               vvvvvvvvvv - what should be the value here?
+ADDRESS_FOR_EXECUTORS=172.17.0.1
+ENDENV
+
+docker pull backenddevelopersltd/compute-horde-executor:v0-latest
+docker pull backenddevelopersltd/compute-horde-miner:v0-latest
+docker pull backenddevelopersltd/compute-horde-job:v0-latest
+docker-compose up -d
+
+ENDSSH

--- a/install_miner.sh
+++ b/install_miner.sh
@@ -16,9 +16,17 @@ if [ ! -f "$LOCAL_HOTKEY_PATH" ]; then
   exit 1
 fi
 
-# BSD (mac) `realpath` does not support `-s` or `--relative-to` :'(
-REMOTE_HOTKEY_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_HOTKEY_PATH', '$HOME'))")
-REMOTE_COLDKEY_PUB_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_COLDKEY_PUB_PATH', '$HOME'))")
+# try to retain the path, but bail if it contains special characters to avoid inconsistent behavious by `.env` readers
+if [[ $LOCAL_HOTKEY_PATH =~ ['$#!;*?&()<>'\"\'] ]]
+then
+  REMOTE_HOTKEY_PATH=.bittensor/wallets/mywallet/hotkeys/default
+  REMOTE_COLDKEY_PUB_PATH=.bittensor/wallets/mywallet/coldkeypub.txt
+else
+  # BSD (i.e. mac) `realpath` does not support `-s` or `--relative-to` :'(
+  REMOTE_HOTKEY_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_HOTKEY_PATH', '$HOME'))")
+  REMOTE_COLDKEY_PUB_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_COLDKEY_PUB_PATH', '$HOME'))")
+fi
+
 REMOTE_HOTKEY_DIR=$(dirname "$REMOTE_HOTKEY_PATH")
 
 # Copy the wallet files to the server

--- a/install_validator.sh
+++ b/install_validator.sh
@@ -75,8 +75,8 @@ services:
 ENDDOCKERCOMPOSE
 
 cat > .env <<ENDENV
-SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(25))')
-POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
+SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe(25))')
+POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')
 BITTENSOR_NETUID=12
 BITTENSOR_NETWORK=finney
 BITTENSOR_WALLET_NAME="$(. ~/tmpvars && echo "$WALLET_NAME")"

--- a/install_validator.sh
+++ b/install_validator.sh
@@ -48,8 +48,24 @@ set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 # install docker
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc
+do
+  sudo apt-get remove $pkg || true
+done
+
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl docker.io docker-compose
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get install -y docker-ce docker-compose-plugin
 sudo usermod -aG docker $USER
 ENDSSH
 
@@ -94,6 +110,6 @@ FACILITATOR_URI=wss://facilitator.computehorde.io/ws/v0/
 ENDENV
 
 docker pull backenddevelopersltd/compute-horde-validator:v0-latest
-docker-compose up -d
+docker compose up -d
 
 ENDSSH

--- a/install_validator.sh
+++ b/install_validator.sh
@@ -16,9 +16,17 @@ if [ ! -f "$LOCAL_HOTKEY_PATH" ]; then
   exit 1
 fi
 
-# BSD (mac) `realpath` does not support `-s` or `--relative-to` :'(
-REMOTE_HOTKEY_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_HOTKEY_PATH', '$HOME'))")
-REMOTE_COLDKEY_PUB_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_COLDKEY_PUB_PATH', '$HOME'))")
+# try to retain the path, but bail if it contains special characters to avoid inconsistent behavious by `.env` readers
+if [[ $LOCAL_HOTKEY_PATH =~ ['$#!;*?&()<>'\"\'] ]]
+then
+  REMOTE_HOTKEY_PATH=.bittensor/wallets/mywallet/hotkeys/default
+  REMOTE_COLDKEY_PUB_PATH=.bittensor/wallets/mywallet/coldkeypub.txt
+else
+  # BSD (i.e. mac) `realpath` does not support `-s` or `--relative-to` :'(
+  REMOTE_HOTKEY_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_HOTKEY_PATH', '$HOME'))")
+  REMOTE_COLDKEY_PUB_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_COLDKEY_PUB_PATH', '$HOME'))")
+fi
+
 REMOTE_HOTKEY_DIR=$(dirname "$REMOTE_HOTKEY_PATH")
 
 # Copy the wallet files to the server

--- a/install_validator.sh
+++ b/install_validator.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ $# -ne 2 ]
+then
+  echo >2 "USAGE: ./install_validator.sh SSH_DESTINATION HOTKEY_PATH"
+  exit 1
+fi
+
+SSH_DESTINATION="$1"
+LOCAL_HOTKEY_PATH=$(realpath "$2")
+LOCAL_COLDKEY_PUB_PATH=$(dirname $(dirname "$LOCAL_HOTKEY_PATH"))/coldkeypub.txt
+
+if [ ! -f $LOCAL_HOTKEY_PATH ]; then
+  echo "Given HOTKEY_PATH does not exist"
+  exit 1
+fi
+
+# BSD (mac) `realpath` does not support `-s` or `--relative-to` :'(
+REMOTE_HOTKEY_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_HOTKEY_PATH', '$HOME'))")
+REMOTE_COLDKEY_PUB_PATH=$(python3 -c "import os.path; print(os.path.relpath('$LOCAL_COLDKEY_PUB_PATH', '$HOME'))")
+REMOTE_HOTKEY_DIR=$(dirname "$REMOTE_HOTKEY_PATH")
+
+# Copy the wallet files to the server
+ssh "$SSH_DESTINATION" <<ENDSSH
+set -euxo pipefail
+
+mkdir -p $REMOTE_HOTKEY_DIR
+cat > tmpvars <<ENDCAT
+HOTKEY_NAME="$(basename "$REMOTE_HOTKEY_PATH")"
+WALLET_NAME="$(basename $(dirname "$REMOTE_HOTKEY_DIR"))"
+ENDCAT
+ENDSSH
+scp "$LOCAL_HOTKEY_PATH" "$SSH_DESTINATION:$REMOTE_HOTKEY_PATH"
+scp "$LOCAL_COLDKEY_PUB_PATH" "$SSH_DESTINATION:$REMOTE_COLDKEY_PUB_PATH"
+
+ssh "$SSH_DESTINATION" <<'ENDSSH'
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# install docker
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl docker.io docker-compose
+sudo usermod -aG docker $USER
+ENDSSH
+
+# start a new ssh connection so that usermod changes are effective
+ssh "$SSH_DESTINATION" <<'ENDSSH'
+set -euxo pipefail
+mkdir ~/compute_horde_validator
+cd ~/compute_horde_validator
+
+cat > docker-compose.yml <<'ENDDOCKERCOMPOSE'
+version: '3.7'
+
+services:
+
+  validator-runner:
+    image: backenddevelopersltd/compute-horde-validator-runner:v0-latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - "$HOME/.bittensor/wallets:/root/.bittensor/wallets"
+      - ./.env:/root/validator/.env
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 60 --cleanup --label-enable
+ENDDOCKERCOMPOSE
+
+cat > .env <<ENDENV
+SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(25))')
+POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
+BITTENSOR_NETUID=12
+BITTENSOR_NETWORK=finney
+BITTENSOR_WALLET_NAME=$(. ~/tmpvars && echo "$WALLET_NAME")
+BITTENSOR_WALLET_HOTKEY_NAME=$(. ~/tmpvars && echo "$HOTKEY_NAME")
+HOST_WALLET_DIR=$HOME/.bittensor/wallets
+FACILITATOR_URI=wss://facilitator.computehorde.io/ws/v0/
+ENDENV
+
+docker pull backenddevelopersltd/compute-horde-validator:v0-latest
+docker-compose up -d
+
+ENDSSH

--- a/install_validator.sh
+++ b/install_validator.sh
@@ -3,16 +3,16 @@ set -euxo pipefail
 
 if [ $# -ne 2 ]
 then
-  echo >2 "USAGE: ./install_validator.sh SSH_DESTINATION HOTKEY_PATH"
+  >&2 echo "USAGE: ./install_validator.sh SSH_DESTINATION HOTKEY_PATH"
   exit 1
 fi
 
 SSH_DESTINATION="$1"
 LOCAL_HOTKEY_PATH=$(realpath "$2")
-LOCAL_COLDKEY_PUB_PATH=$(dirname $(dirname "$LOCAL_HOTKEY_PATH"))/coldkeypub.txt
+LOCAL_COLDKEY_PUB_PATH=$(dirname "$(dirname "$LOCAL_HOTKEY_PATH")")/coldkeypub.txt
 
-if [ ! -f $LOCAL_HOTKEY_PATH ]; then
-  echo "Given HOTKEY_PATH does not exist"
+if [ ! -f "$LOCAL_HOTKEY_PATH" ]; then
+  >&2 echo "Given HOTKEY_PATH does not exist"
   exit 1
 fi
 
@@ -28,12 +28,13 @@ set -euxo pipefail
 mkdir -p $REMOTE_HOTKEY_DIR
 cat > tmpvars <<ENDCAT
 HOTKEY_NAME="$(basename "$REMOTE_HOTKEY_PATH")"
-WALLET_NAME="$(basename $(dirname "$REMOTE_HOTKEY_DIR"))"
+WALLET_NAME="$(basename "$(dirname "$REMOTE_HOTKEY_DIR")")"
 ENDCAT
 ENDSSH
 scp "$LOCAL_HOTKEY_PATH" "$SSH_DESTINATION:$REMOTE_HOTKEY_PATH"
 scp "$LOCAL_COLDKEY_PUB_PATH" "$SSH_DESTINATION:$REMOTE_COLDKEY_PUB_PATH"
 
+# install necessary software in the server
 ssh "$SSH_DESTINATION" <<'ENDSSH'
 set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
@@ -78,8 +79,8 @@ SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(25))')
 POSTGRES_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
 BITTENSOR_NETUID=12
 BITTENSOR_NETWORK=finney
-BITTENSOR_WALLET_NAME=$(. ~/tmpvars && echo "$WALLET_NAME")
-BITTENSOR_WALLET_HOTKEY_NAME=$(. ~/tmpvars && echo "$HOTKEY_NAME")
+BITTENSOR_WALLET_NAME="$(. ~/tmpvars && echo "$WALLET_NAME")"
+BITTENSOR_WALLET_HOTKEY_NAME="$(. ~/tmpvars && echo "$HOTKEY_NAME")"
 HOST_WALLET_DIR=$HOME/.bittensor/wallets
 FACILITATOR_URI=wss://facilitator.computehorde.io/ws/v0/
 ENDENV


### PR DESCRIPTION
heredocs inside heredocs! (╯°□°）╯︵ ┻━┻

The scripts have a lot of repeated code. But I decided to keep them like that, as de-duplicating them would mean complicated templating/code-generation.
But we *may* want to do it anyway, if we *need* similar installer scripts for staging and preprod.

There's one `shellcheck` warning in the scripts:
```
❯ shellcheck install_validator.sh

In install_validator.sh line 25:
ssh "$SSH_DESTINATION" <<ENDSSH
                         ^----^ SC2087 (warning): Quote 'ENDSSH' to make here document expansions happen on the server side rather than on the client.

For more information:
  https://www.shellcheck.net/wiki/SC2087 -- Quote 'ENDSSH' to make here docum...

```
but that is intended. It could be circumvented by preparing the `tmpvars` file locally (in `/tmp` or something) and then transferring it. But I didn't bother.

BTW, `shellcheck` does seem to understand the heredoc is shell script going to remote (ssh). But it does not seem to lint the heredoc itself as shell code. ¯\_(ツ)_/¯

Also, I didn't know where to put them, so I put them in root. LMK where is a better place.