### PR TITLE
Manually release control after websocket.send

### DIFF
--- a/compute_horde/compute_horde/miner_client/base.py
+++ b/compute_horde/compute_horde/miner_client/base.py
@@ -107,6 +107,9 @@ class AbstractMinerClient(abc.ABC):
             await self.ensure_connected()
             try:
                 await self.ws.send(model.model_dump_json())
+                # Summary: https://github.com/python-websockets/websockets/issues/867
+                # Longer discussion: https://github.com/python-websockets/websockets/issues/865
+                await asyncio.sleep(0)
             except websockets.WebSocketException as ex:
                 logger.error(f"Could not send to miner {self.miner_name}: {str(ex)}")
                 await asyncio.sleep(1 + random.random())

--- a/validator/app/src/compute_horde_validator/validator/facilitator_client.py
+++ b/validator/app/src/compute_horde_validator/validator/facilitator_client.py
@@ -211,6 +211,9 @@ class FacilitatorClient:
         if self.ws is None:
             raise websockets.ConnectionClosed
         await self.ws.send(msg.model_dump_json())
+        # Summary: https://github.com/python-websockets/websockets/issues/867
+        # Longer discussion: https://github.com/python-websockets/websockets/issues/865
+        await asyncio.sleep(0)
 
     async def handle_message(self, raw_msg: str | bytes):
         """handle message received from facilitator"""


### PR DESCRIPTION
This should prevent observed hanging on receiving data in facilitator connector.

Issue summarized in:
https://github.com/python-websockets/websockets/issues/867

Longer discussion:
https://github.com/python-websockets/websockets/issues/865

Solution also added in MinerClient.send_model