### PR TITLE
Bash improvements

### DIFF
--- a/docs/build_plantumls.sh
+++ b/docs/build_plantumls.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+
 cd "$(dirname "$0")"
 
 for file in *.puml.txt

--- a/executor/app/build-image.sh
+++ b/executor/app/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-executor:v0-latest"
 # Dockerfile assumes that build is run in the parent dir

--- a/executor/app/publish-image.sh
+++ b/executor/app/publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source ./build-image.sh
 echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/executor/app/src/compute_horde_executor/executor/tests/integration/docker_image_for_tests/push_to_dockerhub.sh
+++ b/executor/app/src/compute_horde_executor/executor/tests/integration/docker_image_for_tests/push_to_dockerhub.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 # Define image
 IMAGE_NAME="backenddevelopersltd/compute-horde-job-echo:v0-latest"

--- a/executor/bin/backup-db-to-email.sh
+++ b/executor/bin/backup-db-to-email.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -eu
 
 if [ "$(basename "$0")" == 'bin' ]; then
   cd ..

--- a/executor/bin/backup-db.sh
+++ b/executor/bin/backup-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/executor/bin/backup-file-to-b2.sh
+++ b/executor/bin/backup-file-to-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/executor/bin/common.sh
+++ b/executor/bin/common.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 
 if [ -z "${_COMMON_SH_LOADED:-}" ]; then
   # Update PATH in case docker-compose is installed via PIP

--- a/executor/bin/list-b2-backups.sh
+++ b/executor/bin/list-b2-backups.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/executor/bin/prepare-os.sh
+++ b/executor/bin/prepare-os.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
-set -eux pipefail
+set -euxo pipefail
 
 DOCKER_BIN="$(command -v docker || true)"
 DOCKER_COMPOSE_BIN="$(command -v docker-compose || true)"

--- a/executor/bin/prepare-os.sh
+++ b/executor/bin/prepare-os.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 set -euxo pipefail
 

--- a/executor/bin/restore-db-from-b2.sh
+++ b/executor/bin/restore-db-from-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/executor/bin/restore-db.sh
+++ b/executor/bin/restore-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/executor/deploy-to-aws.sh
+++ b/executor/deploy-to-aws.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 # shellcheck disable=2086
 ./devops/scripts/build-backend.sh $1
 ./devops/scripts/deploy-backend.sh $1

--- a/executor/deploy.sh
+++ b/executor/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
-set -eux pipefail
+set -euxo pipefail
 
 if [ ! -f ".env" ]; then
     echo "\e[31mPlease setup the environment first!\e[0m";

--- a/executor/deploy.sh
+++ b/executor/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 set -euxo pipefail
 

--- a/executor/letsencrypt_setup.sh
+++ b/executor/letsencrypt_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 RELPATH="$(dirname "$0")"
 ABSPATH="$(realpath "$RELPATH")"

--- a/miner/app/build-image.sh
+++ b/miner/app/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-miner:v0-latest"
 # Dockerfile assumes that build is run in the parent dir

--- a/miner/app/publish-image.sh
+++ b/miner/app/publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source ./build-image.sh
 echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/miner/bin/backup-db-to-email.sh
+++ b/miner/bin/backup-db-to-email.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/bin/bash
+set -eu
 
 if [ "$(basename "$0")" == 'bin' ]; then
   cd ..

--- a/miner/bin/backup-db.sh
+++ b/miner/bin/backup-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/miner/bin/backup-file-to-b2.sh
+++ b/miner/bin/backup-file-to-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/miner/bin/common.sh
+++ b/miner/bin/common.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 
 if [ -z "${_COMMON_SH_LOADED:-}" ]; then
   # Update PATH in case docker-compose is installed via PIP

--- a/miner/bin/list-b2-backups.sh
+++ b/miner/bin/list-b2-backups.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/miner/bin/prepare-os.sh
+++ b/miner/bin/prepare-os.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux pipefail
+set -euxo pipefail
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 
 DOCKER_BIN="$(command -v docker || true)"

--- a/miner/bin/prepare-os.sh
+++ b/miner/bin/prepare-os.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euxo pipefail
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 

--- a/miner/bin/restore-db-from-b2.sh
+++ b/miner/bin/restore-db-from-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/miner/bin/restore-db.sh
+++ b/miner/bin/restore-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/miner/deploy-to-aws.sh
+++ b/miner/deploy-to-aws.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 # shellcheck disable=2086
 ./devops/scripts/build-backend.sh $1
 ./devops/scripts/deploy-backend.sh $1

--- a/miner/deploy.sh
+++ b/miner/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux pipefail
+set -euxo pipefail
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 
 if [ ! -f ".env" ]; then

--- a/miner/deploy.sh
+++ b/miner/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euxo pipefail
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 

--- a/miner/envs/runner/_build-image.sh
+++ b/miner/envs/runner/_build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}"

--- a/miner/envs/runner/_publish-image.sh
+++ b/miner/envs/runner/_publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 if [ -z "$(docker info 2>/dev/null | grep 'Username' | awk '{print $2}')" ]; then
 	echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/miner/envs/runner/build-prod.sh
+++ b/miner/envs/runner/build-prod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./build-image.sh )

--- a/miner/envs/runner/build-staging.sh
+++ b/miner/envs/runner/build-staging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./build-image.sh )

--- a/miner/envs/runner/nginx/build-prod.sh
+++ b/miner/envs/runner/nginx/build-prod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-miner-nginx:v0-latest"
 docker build --platform=linux/amd64 -t "$IMAGE_NAME" .

--- a/miner/envs/runner/nginx/build-staging.sh
+++ b/miner/envs/runner/nginx/build-staging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-miner-nginx:staging-latest"
 docker build --platform=linux/amd64 -t "$IMAGE_NAME" .

--- a/miner/envs/runner/nginx/publish-prod.sh
+++ b/miner/envs/runner/nginx/publish-prod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source build-prod.sh
 echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/miner/envs/runner/nginx/publish-staging.sh
+++ b/miner/envs/runner/nginx/publish-staging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source build-staging.sh
 echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/miner/envs/runner/publish-prod.sh
+++ b/miner/envs/runner/publish-prod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./publish-image.sh )

--- a/miner/envs/runner/publish-staging.sh
+++ b/miner/envs/runner/publish-staging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./publish-image.sh )

--- a/miner/letsencrypt_setup.sh
+++ b/miner/letsencrypt_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 RELPATH="$(dirname "$0")"
 ABSPATH="$(realpath "$RELPATH")"

--- a/validator/app/build-image.sh
+++ b/validator/app/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-validator:v0-latest"
 # Dockerfile assumes that build is run in the parent dir

--- a/validator/app/envs/job/build-image.sh
+++ b/validator/app/envs/job/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 BASE_IMAGE_NAME="backenddevelopersltd/compute-horde-job-base:v0-latest"
 IMAGE_NAME="backenddevelopersltd/compute-horde-job:v0-latest"

--- a/validator/app/envs/job/publish-image.sh
+++ b/validator/app/envs/job/publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source ./build-image.sh
 echo "$GITHUB_CR_PAT" | docker login ghcr.io -u USERNAME --password-stdin

--- a/validator/app/publish-image.sh
+++ b/validator/app/publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source ./build-image.sh
 echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/validator/bin/backup-db-to-email.sh
+++ b/validator/bin/backup-db-to-email.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/bin/bash
+set -eu
 
 if [ "$(basename "$0")" == 'bin' ]; then
   cd ..

--- a/validator/bin/backup-db.sh
+++ b/validator/bin/backup-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/validator/bin/backup-file-to-b2.sh
+++ b/validator/bin/backup-file-to-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/validator/bin/common.sh
+++ b/validator/bin/common.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 
 if [ -z "${_COMMON_SH_LOADED:-}" ]; then
   # Update PATH in case docker-compose is installed via PIP

--- a/validator/bin/list-b2-backups.sh
+++ b/validator/bin/list-b2-backups.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/validator/bin/prepare-os.sh
+++ b/validator/bin/prepare-os.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
-set -eux pipefail
+set -euxo pipefail
 
 DOCKER_BIN="$(command -v docker || true)"
 DOCKER_COMPOSE_BIN="$(command -v docker-compose || true)"

--- a/validator/bin/prepare-os.sh
+++ b/validator/bin/prepare-os.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 set -euxo pipefail
 

--- a/validator/bin/restore-db-from-b2.sh
+++ b/validator/bin/restore-db-from-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/validator/bin/restore-db.sh
+++ b/validator/bin/restore-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/validator/deploy-to-aws.sh
+++ b/validator/deploy-to-aws.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 # shellcheck disable=2086
 ./devops/scripts/build-backend.sh $1
 ./devops/scripts/deploy-backend.sh $1

--- a/validator/deploy.sh
+++ b/validator/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux pipefail
+set -euxo pipefail
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 
 if [ ! -f ".env" ]; then

--- a/validator/deploy.sh
+++ b/validator/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euxo pipefail
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 

--- a/validator/envs/runner/_build-image.sh
+++ b/validator/envs/runner/_build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}"

--- a/validator/envs/runner/_publish-image.sh
+++ b/validator/envs/runner/_publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 if [ -z "$(docker info 2>/dev/null | grep 'Username' | awk '{print $2}')" ]; then
 	echo "$DOCKERHUB_PAT" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/validator/envs/runner/build-prod.sh
+++ b/validator/envs/runner/build-prod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./build-image.sh )

--- a/validator/envs/runner/build-staging.sh
+++ b/validator/envs/runner/build-staging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./build-image.sh )

--- a/validator/envs/runner/nginx/build-image.sh
+++ b/validator/envs/runner/nginx/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 IMAGE_NAME="backenddevelopersltd/compute-horde-validator-nginx:v0-latest"
 docker build -t $IMAGE_NAME .

--- a/validator/envs/runner/nginx/publish-image.sh
+++ b/validator/envs/runner/nginx/publish-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 source ./build-image.sh
 if [ -z "$(docker info 2>/dev/null | grep 'Username' | awk '{print $2}')" ]; then

--- a/validator/envs/runner/publish-prod.sh
+++ b/validator/envs/runner/publish-prod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./publish-image.sh )

--- a/validator/envs/runner/publish-staging.sh
+++ b/validator/envs/runner/publish-staging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ( cd "${SCRIPT_DIR}/nginx" && ./publish-image.sh )

--- a/validator/letsencrypt_setup.sh
+++ b/validator/letsencrypt_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -euxo pipefail
 
 RELPATH="$(dirname "$0")"
 ABSPATH="$(realpath "$RELPATH")"


### PR DESCRIPTION
- Some scripts used `pipefail` without `-o`, which doesn't make sense, so that's pretty much a bugfix
- Many scripts had `-eux -o` that were merged to `-euxo`
- I don't really like mixing `set` with shebang-located bash flags; for cohesion, I moved all shebang-placed flags into `set` commands

I also addressed one shellcheck issue in 68e3234.

Aside from these changes, I'd recommend:
- using `-E` for scripts that use subshells (there's a lot of them)
- using `command`/`builtin` where it makes sense
- copying env vars to scripts using `!#/usr/bin/env bash` instead of `!#/bin/bash` where that's not breaking
- not using `.sh` extension for Bash/other shell scripts, it's misleading

let me know if you wish some of these implemented :)