### PR TITLE
Adhere to PEP 621

### DIFF
--- a/compute_horde/pyproject.toml
+++ b/compute_horde/pyproject.toml
@@ -1,8 +1,7 @@
 [project]
 name = "compute-horde"
-dynamic = ["version"]
-authors = [{name = "Backend Developers LTD"}]
-license = {text = "MIT License"}
+authors = [{ name = "Backend Developers LTD" }]
+license = { text = "MIT License" }
 readme = "README.md"
 requires-python = "==3.11.*"
 dependencies = [
@@ -12,6 +11,7 @@ dependencies = [
     "more-itertools>=10.2.0",
     "requests>=2.32.2",
 ]
+dynamic = ["version"]
 
 [build-system]
 requires = ["pdm-backend"]
@@ -29,13 +29,8 @@ tag_regex = '^library-v(?P<version>\d+\.\d+\.\d+(a\d+)?)$'
 
 [tool.pdm.dev-dependencies]
 format = ["ruff"]
-lint = [
-    "ruff",
-    "codespell[toml]",
-]
-release = [
-    "towncrier>=23.11.0,<24",
-]
+lint = ["ruff", "codespell[toml]"]
+release = ["towncrier>=23.11.0,<24"]
 type_check = [
     "django-stubs[compatible-mypy]",
     "djangorestframework-stubs[compatible-mypy]",
@@ -44,11 +39,7 @@ type_check = [
     "types-python-dateutil",
     "types-requests",
 ]
-test = [
-    "pytest>=8.2.1",
-    "responses>=0.25.0",
-    "freezegun>=1.5.1",
-]
+test = ["pytest>=8.2.1", "responses>=0.25.0", "freezegun>=1.5.1"]
 
 [tool.ruff]
 line-length = 100
@@ -58,8 +49,21 @@ line-length = 100
 select = ["E", "F", "I", "UP"]
 # TODO: remove E501 once docstrings are formatted
 ignore = [
-    "D100", "D105", "D107", "D200", "D202", "D203", "D205", "D212", "D400", "D401", "D415",
-    "D101", "D102","D103", "D104", # TODO remove once we have docstring for all public methods
+    "D100",
+    "D105",
+    "D107",
+    "D200",
+    "D202",
+    "D203",
+    "D205",
+    "D212",
+    "D400",
+    "D401",
+    "D415",
+    "D101",
+    "D102",
+    "D103",
+    "D104", # TODO remove once we have docstring for all public methods
     "E501", # TODO: remove E501 once docstrings are formatted
 ]
 

--- a/compute_horde/pyproject.toml
+++ b/compute_horde/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
 [project]
 name = "compute-horde"
 authors = [{ name = "Backend Developers LTD" }]
@@ -12,10 +16,6 @@ dependencies = [
     "requests>=2.32.2",
 ]
 dynamic = ["version"]
-
-[build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
 
 [tool.pdm]
 distribution = true

--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -1,8 +1,6 @@
 [project]
 name = "executor"
 requires-python = "==3.11.*"
-version = "0"
-
 dependencies = [
     "Django~=4.2.4",
     "django-cors-headers~=4.2.0",
@@ -26,6 +24,7 @@ dependencies = [
     "django-prometheus==2.3.1",
     "django-business-metrics @ git+https://github.com/reef-technologies/django-business-metrics.git@9d08ddb3a9d26e8a7e478110d7c8c34c3aa03a01",
 ]
+dynamic = ["version"]
 
 [build-system]
 requires = ["pdm-backend"]
@@ -44,13 +43,8 @@ test = [
     "freezegun",
     "requests-toolbelt>=1.0.0",
 ]
-format = [
-    "ruff",
-]
-lint = [
-    "ruff",
-    "codespell[toml]",
-]
+format = ["ruff"]
+lint = ["ruff", "codespell[toml]"]
 type_check = [
     "django-stubs[compatible-mypy]",
     "djangorestframework-stubs[compatible-mypy]",
@@ -59,9 +53,7 @@ type_check = [
     "types-python-dateutil",
     "types-requests",
 ]
-security_check = [
-    "bandit>=1.7.7",
-]
+security_check = ["bandit>=1.7.7"]
 
 [tool.ruff]
 src = ["app/src"]
@@ -72,8 +64,21 @@ line-length = 100
 select = ["E", "F", "I", "UP"]
 # TODO: remove E501 once docstrings are formatted
 ignore = [
-    "D100", "D105", "D107", "D200", "D202", "D203", "D205", "D212", "D400", "D401", "D415",
-    "D101", "D102","D103", "D104", # TODO remove once we have docstring for all public methods
+    "D100",
+    "D105",
+    "D107",
+    "D200",
+    "D202",
+    "D203",
+    "D205",
+    "D212",
+    "D400",
+    "D401",
+    "D415",
+    "D101",
+    "D102",
+    "D103",
+    "D104", # TODO remove once we have docstring for all public methods
     "E501", # TODO: remove E501 once docstrings are formatted
 ]
 

--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
 [project]
 name = "executor"
 requires-python = "==3.11.*"
@@ -25,10 +29,6 @@ dependencies = [
     "django-business-metrics @ git+https://github.com/reef-technologies/django-business-metrics.git@9d08ddb3a9d26e8a7e478110d7c8c34c3aa03a01",
 ]
 dynamic = ["version"]
-
-[build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
 
 [tool.pdm]
 distribution = false

--- a/miner/pyproject.toml
+++ b/miner/pyproject.toml
@@ -1,8 +1,6 @@
 [project]
 name = "miner"
 requires-python = "==3.11.*"
-version = "0"
-
 dependencies = [
     "Django~=4.2.4",
     "django-cors-headers~=4.2.0",
@@ -26,6 +24,7 @@ dependencies = [
     "django-business-metrics @ git+https://github.com/reef-technologies/django-business-metrics.git@9d08ddb3a9d26e8a7e478110d7c8c34c3aa03a01",
     "django-constance[database]==3.1.0",
 ]
+dynamic = ["version"]
 
 [build-system]
 requires = ["pdm-backend"]
@@ -45,13 +44,8 @@ test = [
     "pytest-mock>=3.14.0",
     "faker>=26.0.0",
 ]
-format = [
-    "ruff",
-]
-lint = [
-    "ruff",
-    "codespell[toml]",
-]
+format = ["ruff"]
+lint = ["ruff", "codespell[toml]"]
 type_check = [
     "django-stubs[compatible-mypy]",
     "djangorestframework-stubs[compatible-mypy]",
@@ -60,9 +54,7 @@ type_check = [
     "types-python-dateutil",
     "types-requests",
 ]
-security_check = [
-    "bandit>=1.7.7",
-]
+security_check = ["bandit>=1.7.7"]
 
 [tool.ruff]
 src = ["app/src"]
@@ -73,8 +65,21 @@ line-length = 100
 select = ["E", "F", "I", "UP"]
 # TODO: remove E501 once docstrings are formatted
 ignore = [
-    "D100", "D105", "D107", "D200", "D202", "D203", "D205", "D212", "D400", "D401", "D415",
-    "D101", "D102","D103", "D104", # TODO remove once we have docstring for all public methods
+    "D100",
+    "D105",
+    "D107",
+    "D200",
+    "D202",
+    "D203",
+    "D205",
+    "D212",
+    "D400",
+    "D401",
+    "D415",
+    "D101",
+    "D102",
+    "D103",
+    "D104", # TODO remove once we have docstring for all public methods
     "E501", # TODO: remove E501 once docstrings are formatted
 ]
 

--- a/miner/pyproject.toml
+++ b/miner/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
 [project]
 name = "miner"
 requires-python = "==3.11.*"
@@ -25,10 +29,6 @@ dependencies = [
     "django-constance[database]==3.1.0",
 ]
 dynamic = ["version"]
-
-[build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
 
 [tool.pdm]
 distribution = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
+name = "ComputeHorde"
 dependencies = []
 requires-python = "==3.11.*"
+dynamic = ["version"]
 
 [tool.pdm.dev-dependencies]
 dev = [

--- a/validator/pyproject.toml
+++ b/validator/pyproject.toml
@@ -1,8 +1,6 @@
 [project]
 name = "validator"
 requires-python = "==3.11.*"
-version = "0"
-
 dependencies = [
     "Django~=4.2.4",
     "django-cors-headers~=4.2.0",
@@ -30,6 +28,7 @@ dependencies = [
     "django-admin-rangefilter==0.12.4",
     "bittensor==7.3.0",
 ]
+dynamic = ["version"]
 
 [build-system]
 requires = ["pdm-backend"]
@@ -49,13 +48,8 @@ test = [
     "freezegun",
     "pytest-mock>=3.14.0",
 ]
-format = [
-    "ruff",
-]
-lint = [
-    "ruff",
-    "codespell[toml]",
-]
+format = ["ruff"]
+lint = ["ruff", "codespell[toml]"]
 type_check = [
     "django-stubs[compatible-mypy]",
     "djangorestframework-stubs[compatible-mypy]",
@@ -64,9 +58,7 @@ type_check = [
     "types-python-dateutil",
     "types-requests",
 ]
-security_check = [
-    "bandit>=1.7.7",
-]
+security_check = ["bandit>=1.7.7"]
 
 [tool.ruff]
 src = ["app/src"]
@@ -74,14 +66,24 @@ line-length = 100
 
 [tool.ruff.lint]
 # TODO add D
-select = [
-    "E", "F", "I", "UP",
-    "TCH005",
-]
+select = ["E", "F", "I", "UP", "TCH005"]
 # TODO: remove E501 once docstrings are formatted
 ignore = [
-    "D100", "D105", "D107", "D200", "D202", "D203", "D205", "D212", "D400", "D401", "D415",
-    "D101", "D102","D103", "D104", # TODO remove once we have docstring for all public methods
+    "D100",
+    "D105",
+    "D107",
+    "D200",
+    "D202",
+    "D203",
+    "D205",
+    "D212",
+    "D400",
+    "D401",
+    "D415",
+    "D101",
+    "D102",
+    "D103",
+    "D104", # TODO remove once we have docstring for all public methods
     "E501", # TODO: remove E501 once docstrings are formatted
 ]
 

--- a/validator/pyproject.toml
+++ b/validator/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
 [project]
 name = "validator"
 requires-python = "==3.11.*"
@@ -29,10 +33,6 @@ dependencies = [
     "bittensor==7.3.0",
 ]
 dynamic = ["version"]
-
-[build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
 
 [tool.pdm]
 distribution = false


### PR DESCRIPTION
Currently, `./miner`, `./executor` and `./validator` aren't installable in editable mode.
There were several issues with validating your `pyproject.toml`s against the schemas.
I've also reformatted these as a side effect; let me know if that's an issue (given you're using `.git-blame-ignore-revs` and formatting affected some lines) and you'd like to keep the old formatting.