### PR TITLE
Make synthetic jobs tests more integration

### DIFF
--- a/compute_horde/compute_horde/transport/__init__.py
+++ b/compute_horde/compute_horde/transport/__init__.py
@@ -1,8 +1,10 @@
 from .base import AbstractTransport, TransportConnectionError
+from .stub import StubTransport
 from .ws import WSTransport
 
 __all__ = [
     "AbstractTransport",
     "TransportConnectionError",
     "WSTransport",
+    "StubTransport",
 ]

--- a/compute_horde/compute_horde/transport/stub.py
+++ b/compute_horde/compute_horde/transport/stub.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from .base import AbstractTransport
+
+
+class StubTransport(AbstractTransport):
+    """
+    Stub transport for testing purposes.
+    Receives predefined list of messages and saves sent messages in the internal state
+    """
+
+    def __init__(self, name: str, messages: list[str], *args, **kwargs):
+        self.sent: list[str] = []
+        self.messages = messages
+        self.sent_messages: list[str] = []
+
+    async def start(self): ...
+
+    async def stop(self): ...
+
+    async def send(self, message):
+        self.sent_messages.append(message)
+
+    async def receive(self):
+        try:
+            return next(self.messages)
+        except StopIteration:
+            await asyncio.Future()

--- a/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
+++ b/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import io
 import json
@@ -11,7 +10,7 @@ from functools import partial
 from unittest import mock
 
 import httpx
-from compute_horde.transport import AbstractTransport
+from compute_horde.transport import StubTransport
 from pytest_httpx import HTTPXMock
 from requests_toolbelt.multipart import decoder
 
@@ -55,29 +54,9 @@ def get_file_from_request(request):
     return parsed_data
 
 
-class MockTransport(AbstractTransport):
-    def __init__(self, messages: list[str]):
-        self.sent: list[str] = []
-        self.messages = messages
-        self.sent_messages: list[str] = []
-
-    async def start(self): ...
-
-    async def stop(self): ...
-
-    async def send(self, message):
-        self.sent_messages.append(message)
-
-    async def receive(self):
-        try:
-            return next(self.messages)
-        except StopIteration:
-            await asyncio.Future()
-
-
 class TestCommand(Command):
     def __init__(self, messages, *args, **kwargs):
-        transport = MockTransport(messages)
+        transport = StubTransport("test", messages)
         self.MINER_CLIENT_CLASS = partial(MinerClient, transport=transport)
         super().__init__(*args, **kwargs)
 

--- a/validator/app/src/compute_horde_validator/validator/synthetic_jobs/batch_run.py
+++ b/validator/app/src/compute_horde_validator/validator/synthetic_jobs/batch_run.py
@@ -46,7 +46,7 @@ from compute_horde.mv_protocol.validator_requests import (
     V0JobStartedReceiptRequest,
     VolumeType,
 )
-from compute_horde.transport import WSTransport
+from compute_horde.transport import AbstractTransport, WSTransport
 from django.conf import settings
 from django.db import transaction
 from pydantic import BaseModel
@@ -92,7 +92,12 @@ _MAX_MINER_CLIENT_DEBOUNCE_COUNT = 4  # approximately 32 seconds
 
 
 class MinerClient(AbstractMinerClient):
-    def __init__(self, ctx: "BatchContext", miner_hotkey: str):
+    def __init__(
+        self,
+        ctx: "BatchContext",
+        miner_hotkey: str,
+        transport: AbstractTransport | None = None,
+    ):
         self.ctx = ctx
         self.own_hotkey = ctx.own_keypair.ss58_address
         self.own_keypair = ctx.own_keypair
@@ -103,7 +108,7 @@ class MinerClient(AbstractMinerClient):
         self.miner_port = axon.port
 
         name = ctx.names[miner_hotkey]
-        transport = WSTransport(
+        transport = transport or WSTransport(
             name, self.miner_url(), max_retries=_MAX_MINER_CLIENT_DEBOUNCE_COUNT
         )
         super().__init__(name, transport)

--- a/validator/app/src/compute_horde_validator/validator/synthetic_jobs/batch_run.py
+++ b/validator/app/src/compute_horde_validator/validator/synthetic_jobs/batch_run.py
@@ -5,6 +5,7 @@ import statistics
 import time
 import uuid
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -554,11 +555,13 @@ def _init_context(
     axons: dict[str, bittensor.AxonInfo],
     serving_miners: list[Miner],
     batch_id: int | None = None,
+    create_miner_client: Callable | None = None,
 ) -> BatchContext:
     start_time = datetime.now(tz=UTC)
 
     own_wallet = settings.BITTENSOR_WALLET()
     own_keypair = own_wallet.get_hotkey()
+    create_miner_client = create_miner_client or MinerClient
 
     ctx = BatchContext(
         uuid=str(uuid.uuid4()),
@@ -589,7 +592,7 @@ def _init_context(
         ctx.axons[hotkey] = axon
         ctx.names[hotkey] = f"{hotkey}({axon.ip}:{axon.port})"
         ctx.miners[hotkey] = miner
-        ctx.clients[hotkey] = MinerClient(ctx=ctx, miner_hotkey=hotkey)
+        ctx.clients[hotkey] = create_miner_client(ctx=ctx, miner_hotkey=hotkey)
         ctx.executors[hotkey] = defaultdict(int)
         ctx.job_generators[hotkey] = {}
         ctx.online_executor_count[hotkey] = 0
@@ -1312,6 +1315,7 @@ async def execute_synthetic_batch_run(
     axons: dict[str, bittensor.AxonInfo],
     serving_miners: list[Miner],
     batch_id: int | None = None,
+    create_miner_client: Callable | None = None,
 ) -> None:
     if not axons or not serving_miners:
         logger.warning("No miners provided")
@@ -1322,7 +1326,7 @@ async def execute_synthetic_batch_run(
     random.shuffle(serving_miners)
 
     logger.info("STAGE: _init_context")
-    ctx = _init_context(axons, serving_miners, batch_id)
+    ctx = _init_context(axons, serving_miners, batch_id, create_miner_client)
 
     try:
         logger.info("STAGE: _db_get_previous_online_executor_count")

--- a/validator/app/src/compute_horde_validator/validator/tests/mock_generator.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/mock_generator.py
@@ -9,6 +9,7 @@ from compute_horde_validator.validator.synthetic_jobs.generator.base import (
 )
 
 MOCK_SCORE = 0.8
+NOT_SCORED = 0.0
 
 
 class MockSyntheticJobGenerator(BaseSyntheticJobGenerator):
@@ -16,7 +17,7 @@ class MockSyntheticJobGenerator(BaseSyntheticJobGenerator):
         pass
 
     def timeout_seconds(self) -> int:
-        return 2
+        return 1
 
     def base_docker_image_name(self) -> str:
         return "mock"

--- a/validator/app/src/compute_horde_validator/validator/tests/mock_generator.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/mock_generator.py
@@ -1,0 +1,50 @@
+from compute_horde.executor_class import ExecutorClass
+from compute_horde.mv_protocol.miner_requests import (
+    V0JobFinishedRequest,
+)
+
+from compute_horde_validator.validator.synthetic_jobs.generator.base import (
+    BaseSyntheticJobGenerator,
+    BaseSyntheticJobGeneratorFactory,
+)
+
+MOCK_SCORE = 0.8
+
+
+class MockSyntheticJobGenerator(BaseSyntheticJobGenerator):
+    async def ainit(self):
+        pass
+
+    def timeout_seconds(self) -> int:
+        return 2
+
+    def base_docker_image_name(self) -> str:
+        return "mock"
+
+    def docker_image_name(self) -> str:
+        return "mock"
+
+    def docker_run_options_preset(self) -> str:
+        return "mock"
+
+    def docker_run_cmd(self) -> list[str]:
+        return ["mock"]
+
+    async def volume_contents(self) -> str:
+        return "mock"
+
+    def verify(self, msg: V0JobFinishedRequest, time_took: float) -> tuple[bool, str, float]:
+        return True, "mock", MOCK_SCORE
+
+    def job_description(self) -> str:
+        return "mock"
+
+
+class TimeToookScoreMockSyntheticJobGenerator(MockSyntheticJobGenerator):
+    def verify(self, msg: V0JobFinishedRequest, time_took: float) -> tuple[bool, str, float]:
+        return True, "mock", 1 / time_took
+
+
+class MockSyntheticJobGeneratorFactory(BaseSyntheticJobGeneratorFactory):
+    async def create(self, executor_class: ExecutorClass) -> BaseSyntheticJobGenerator:
+        return MockSyntheticJobGenerator()

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs.py
@@ -1,9 +1,11 @@
 import asyncio
 import uuid
+from unittest.mock import patch
 
 import bittensor
 import pytest
 import pytest_asyncio
+from asgiref.sync import sync_to_async
 from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS
 from compute_horde.miner_client.base import AbstractTransport
 from compute_horde.mv_protocol import miner_requests
@@ -15,15 +17,21 @@ from compute_horde_validator.validator.models import (
     Miner,
     SyntheticJob,
     SyntheticJobBatch,
+    SystemEvent,
 )
 from compute_horde_validator.validator.synthetic_jobs.utils import (
     execute_miner_synthetic_jobs,
 )
 from compute_horde_validator.validator.tests.mock_generator import (
     MOCK_SCORE,
+    NOT_SCORED,
     MockSyntheticJobGeneratorFactory,
 )
 from compute_horde_validator.validator.tests.transport import MinerSimulationTransport
+
+from .helpers import (
+    check_system_events,
+)
 
 
 @pytest.fixture
@@ -93,6 +101,11 @@ def accept_job_message(job_uuid: uuid.UUID):
 
 
 @pytest.fixture
+def decline_job_message(job_uuid: uuid.UUID):
+    return miner_requests.V0DeclineJobRequest(job_uuid=str(job_uuid)).model_dump_json()
+
+
+@pytest.fixture
 def docker_process_stdout():
     return "stdout"
 
@@ -106,6 +119,16 @@ def docker_process_stderr():
 def job_finish_message(job_uuid: uuid.UUID, docker_process_stdout: str, docker_process_stderr: str):
     return miner_requests.V0JobFinishedRequest(
         job_uuid=str(job_uuid),
+        docker_process_stdout=docker_process_stdout,
+        docker_process_stderr=docker_process_stderr,
+    ).model_dump_json()
+
+
+@pytest.fixture
+def job_failed_message(job_uuid: uuid.UUID, docker_process_stdout: str, docker_process_stderr: str):
+    return miner_requests.V0JobFailedRequest(
+        job_uuid=str(job_uuid),
+        docker_process_exit_status=1,
         docker_process_stdout=docker_process_stdout,
         docker_process_stderr=docker_process_stderr,
     ).model_dump_json()
@@ -140,9 +163,9 @@ def _patch_generator_factory(mocker: MockerFixture):
     )
 
 
-@pytest.mark.asyncio(loop_scope="module")
-@pytest.mark.django_db
-async def test_execute_miner_synthetic_jobs(
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_execute_miner_synthetic_jobs_success(
     miner: Miner,
     batch: SyntheticJobBatch,
     miner_hotkey: str,
@@ -152,7 +175,7 @@ async def test_execute_miner_synthetic_jobs(
     executor_ready_message: str,
     accept_job_message: str,
     job_finish_message: str,
-    transport: AbstractTransport,
+    transport: MinerSimulationTransport,
     job_uuid: uuid.UUID,
 ):
     await transport.add_message(manifest_message, send_before=1)
@@ -170,10 +193,164 @@ async def test_execute_miner_synthetic_jobs(
             miner_client,
             generate_job_uuid=lambda: job_uuid,
         ),
+        timeout=1,
+    )
+
+    await check_synthetic_job(job_uuid, miner, SyntheticJob.Status.COMPLETED, MOCK_SCORE)
+    await sync_to_async(check_system_events)(
+        SystemEvent.EventType.MINER_SYNTHETIC_JOB_SUCCESS, SystemEvent.EventSubType.SUCCESS
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@patch("compute_horde_validator.validator.synthetic_jobs.utils.TIMEOUT_LEEWAY", 0.05)
+@patch("compute_horde_validator.validator.synthetic_jobs.utils.TIMEOUT_MARGIN", 0.05)
+async def test_execute_miner_synthetic_jobs_success_timeout(
+    miner: Miner,
+    batch: SyntheticJobBatch,
+    miner_hotkey: str,
+    miner_axon_info: bittensor.AxonInfo,
+    miner_client: MinerClient,
+    manifest_message: str,
+    executor_ready_message: str,
+    accept_job_message: str,
+    job_finish_message: str,
+    transport: MinerSimulationTransport,
+    job_uuid: uuid.UUID,
+):
+    await transport.add_message(manifest_message, send_before=1)
+    await transport.add_message(executor_ready_message, send_before=1)
+    await transport.add_message(accept_job_message, send_before=2)
+    await transport.add_message(job_finish_message, send_before=0, sleep_before=2)
+
+    await asyncio.wait_for(
+        execute_miner_synthetic_jobs(
+            batch.pk,
+            miner.pk,
+            miner_hotkey,
+            miner_axon_info,
+            None,
+            miner_client,
+            generate_job_uuid=lambda: job_uuid,
+        ),
         timeout=2,
     )
 
-    job = await SyntheticJob.objects.aget(job_uuid=job_uuid)
+    await check_synthetic_job(job_uuid, miner, SyntheticJob.Status.FAILED, NOT_SCORED)
+    await sync_to_async(check_system_events)(
+        SystemEvent.EventType.MINER_SYNTHETIC_JOB_FAILURE,
+        SystemEvent.EventSubType.JOB_EXECUTION_TIMEOUT,
+    )
 
-    assert job.status == SyntheticJob.Status.COMPLETED
-    assert job.score == MOCK_SCORE
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_execute_miner_synthetic_jobs_job_failed(
+    miner: Miner,
+    batch: SyntheticJobBatch,
+    miner_hotkey: str,
+    miner_axon_info: bittensor.AxonInfo,
+    miner_client: MinerClient,
+    manifest_message: str,
+    executor_ready_message: str,
+    accept_job_message: str,
+    job_failed_message: str,
+    transport: MinerSimulationTransport,
+    job_uuid: uuid.UUID,
+):
+    await transport.add_message(manifest_message, send_before=1)
+    await transport.add_message(executor_ready_message, send_before=1)
+    await transport.add_message(accept_job_message, send_before=2)
+    await transport.add_message(job_failed_message, send_before=0)
+
+    await asyncio.wait_for(
+        execute_miner_synthetic_jobs(
+            batch.pk,
+            miner.pk,
+            miner_hotkey,
+            miner_axon_info,
+            None,
+            miner_client,
+            generate_job_uuid=lambda: job_uuid,
+        ),
+        timeout=1,
+    )
+
+    await check_synthetic_job(job_uuid, miner, SyntheticJob.Status.FAILED, NOT_SCORED)
+    await sync_to_async(check_system_events)(
+        SystemEvent.EventType.MINER_SYNTHETIC_JOB_FAILURE, SystemEvent.EventSubType.FAILURE
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_execute_miner_synthetic_jobs_job_declined(
+    miner: Miner,
+    batch: SyntheticJobBatch,
+    miner_hotkey: str,
+    miner_axon_info: bittensor.AxonInfo,
+    miner_client: MinerClient,
+    manifest_message: str,
+    decline_job_message: str,
+    transport: MinerSimulationTransport,
+    job_uuid: uuid.UUID,
+):
+    await transport.add_message(manifest_message, send_before=1)
+    await transport.add_message(decline_job_message, send_before=1)
+
+    await asyncio.wait_for(
+        execute_miner_synthetic_jobs(
+            batch.pk,
+            miner.pk,
+            miner_hotkey,
+            miner_axon_info,
+            None,
+            miner_client,
+            generate_job_uuid=lambda: job_uuid,
+        ),
+        timeout=1,
+    )
+
+    await check_synthetic_job(job_uuid, miner, SyntheticJob.Status.FAILED, NOT_SCORED)
+    await sync_to_async(check_system_events)(
+        SystemEvent.EventType.MINER_SYNTHETIC_JOB_FAILURE, SystemEvent.EventSubType.JOB_NOT_STARTED
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@patch("compute_horde_validator.validator.synthetic_jobs.utils.MANIFEST_TIMEOUT", 0.2)
+async def test_execute_miner_synthetic_jobs_no_manifest(
+    miner: Miner,
+    batch: SyntheticJobBatch,
+    miner_hotkey: str,
+    miner_axon_info: bittensor.AxonInfo,
+    miner_client: MinerClient,
+    job_uuid: uuid.UUID,
+):
+    await asyncio.wait_for(
+        execute_miner_synthetic_jobs(
+            batch.pk,
+            miner.pk,
+            miner_hotkey,
+            miner_axon_info,
+            None,
+            miner_client,
+            generate_job_uuid=lambda: job_uuid,
+        ),
+        timeout=1,
+    )
+
+    assert not await SyntheticJob.objects.aexists()
+    await sync_to_async(check_system_events)(
+        SystemEvent.EventType.MINER_SYNTHETIC_JOB_FAILURE, SystemEvent.EventSubType.MANIFEST_ERROR
+    )
+
+
+async def check_synthetic_job(job_uuid: uuid.UUID, miner: Miner, status: str, score: float):
+    job = await SyntheticJob.objects.aget()
+    assert job.job_uuid == job_uuid
+    assert job.miner_id == miner.pk
+    assert job.status == status
+    assert job.score == score

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs.py
@@ -1,2 +1,165 @@
-def test_execute_miner_synthetic_jobs():
-    pass
+import asyncio
+import uuid
+
+import bittensor
+import pytest
+import pytest_asyncio
+from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS
+from compute_horde.miner_client.base import AbstractTransport
+from compute_horde.mv_protocol import miner_requests
+from django.conf import settings
+
+from compute_horde_validator.validator.miner_client import MinerClient
+from compute_horde_validator.validator.models import (
+    Miner,
+    SyntheticJob,
+    SyntheticJobBatch,
+)
+from compute_horde_validator.validator.synthetic_jobs.utils import (
+    execute_miner_synthetic_jobs,
+)
+from compute_horde_validator.validator.tests.transport import MinerSimulationTransport
+
+
+@pytest.fixture
+def miner_hotkey():
+    return "miner_hotkey"
+
+
+@pytest.fixture
+def validator_hotkey():
+    return "validator_hotkey"
+
+
+@pytest.fixture
+def miner_axon_info(miner_hotkey: str):
+    return bittensor.AxonInfo(
+        version=4,
+        ip="ignore",
+        ip_type=4,
+        port=9999,
+        hotkey=miner_hotkey,
+        coldkey=miner_hotkey,
+    )
+
+
+@pytest_asyncio.fixture
+async def miner(miner_hotkey: str):
+    return await Miner.objects.acreate(hotkey=miner_hotkey)
+
+
+@pytest_asyncio.fixture
+async def batch():
+    return await SyntheticJobBatch.objects.acreate(
+        started_at="2021-09-01 00:00:00",
+        accepting_results_until="2021-09-01 00:00:00",
+    )
+
+
+@pytest.fixture
+def keypair():
+    return settings.BITTENSOR_WALLET().get_hotkey()
+
+
+@pytest.fixture
+def job_uuid():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def manifest_message():
+    return miner_requests.V0ExecutorManifestRequest(
+        manifest=miner_requests.ExecutorManifest(
+            executor_classes=[
+                miner_requests.ExecutorClassManifest(executor_class=DEFAULT_EXECUTOR_CLASS, count=1)
+            ]
+        )
+    ).model_dump_json()
+
+
+@pytest.fixture
+def executor_ready_message(job_uuid: uuid.UUID):
+    return miner_requests.V0ExecutorReadyRequest(job_uuid=str(job_uuid)).model_dump_json()
+
+
+@pytest.fixture
+def accept_job_message(job_uuid: uuid.UUID):
+    return miner_requests.V0AcceptJobRequest(job_uuid=str(job_uuid)).model_dump_json()
+
+
+@pytest.fixture
+def docker_process_stdout():
+    return "stdout"
+
+
+@pytest.fixture
+def docker_process_stderr():
+    return "stderr"
+
+
+@pytest.fixture
+def job_finish_message(job_uuid: uuid.UUID, docker_process_stdout: str, docker_process_stderr: str):
+    return miner_requests.V0JobFinishedRequest(
+        job_uuid=str(job_uuid),
+        docker_process_stdout=docker_process_stdout,
+        docker_process_stderr=docker_process_stderr,
+    ).model_dump_json()
+
+
+@pytest_asyncio.fixture
+async def transport(miner_hotkey: str):
+    return MinerSimulationTransport(miner_hotkey)
+
+
+@pytest_asyncio.fixture
+async def miner_client(
+    miner_hotkey: str, validator_hotkey: str, keypair, job_uuid: str, transport: AbstractTransport
+):
+    return MinerClient(
+        miner_address="ignore",
+        my_hotkey=validator_hotkey,
+        miner_hotkey=miner_hotkey,
+        miner_port=9999,
+        job_uuid=job_uuid,
+        batch_id=None,
+        keypair=keypair,
+        transport=transport,
+    )
+
+
+@pytest.mark.asyncio(loop_scope="module")
+@pytest.mark.django_db
+async def test_execute_miner_synthetic_jobs(
+    miner: Miner,
+    batch: SyntheticJobBatch,
+    miner_hotkey: str,
+    miner_axon_info: bittensor.AxonInfo,
+    miner_client: MinerClient,
+    manifest_message: str,
+    executor_ready_message: str,
+    accept_job_message: str,
+    job_finish_message: str,
+    transport: AbstractTransport,
+    job_uuid: uuid.UUID,
+):
+    await transport.add_message(manifest_message, receive_before=1)
+    await transport.add_message(executor_ready_message, receive_before=1)
+    await transport.add_message(accept_job_message, receive_before=0)
+    await transport.add_message(job_finish_message, receive_before=1)
+
+    await asyncio.wait_for(
+        execute_miner_synthetic_jobs(
+            batch.pk,
+            miner.pk,
+            miner_hotkey,
+            miner_axon_info,
+            None,
+            miner_client,
+            generate_job_uuid=lambda: job_uuid,
+        ),
+        timeout=2,
+    )
+
+    job = await SyntheticJob.objects.aget(job_uuid=job_uuid)
+
+    assert job.status == SyntheticJob.Status.COMPLETED

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs.py
@@ -1,0 +1,2 @@
+def test_execute_miner_synthetic_jobs():
+    pass

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/conftest.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/conftest.py
@@ -38,6 +38,13 @@ def miner_axon_info(miner_hotkey: str):
     )
 
 
+@pytest.fixture
+def axon_dict(miner_hotkey: str, miner_axon_info: bittensor.AxonInfo):
+    return {
+        miner_hotkey: miner_axon_info,
+    }
+
+
 @pytest_asyncio.fixture
 async def miner(miner_hotkey: str):
     return await Miner.objects.acreate(hotkey=miner_hotkey)

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/conftest.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/conftest.py
@@ -6,12 +6,8 @@ import pytest_asyncio
 from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS
 from compute_horde.miner_client.base import AbstractTransport
 from compute_horde.mv_protocol import miner_requests
-from django.conf import settings
 
-from compute_horde_validator.validator.models import (
-    Miner,
-    SyntheticJobBatch,
-)
+from compute_horde_validator.validator.models import Miner
 from compute_horde_validator.validator.synthetic_jobs.batch_run import BatchContext, MinerClient
 from compute_horde_validator.validator.tests.transport import MinerSimulationTransport
 
@@ -48,19 +44,6 @@ def axon_dict(miner_hotkey: str, miner_axon_info: bittensor.AxonInfo):
 @pytest_asyncio.fixture
 async def miner(miner_hotkey: str):
     return await Miner.objects.acreate(hotkey=miner_hotkey)
-
-
-@pytest_asyncio.fixture
-async def batch():
-    return await SyntheticJobBatch.objects.acreate(
-        started_at="2021-09-01 00:00:00",
-        accepting_results_until="2021-09-01 00:00:00",
-    )
-
-
-@pytest.fixture
-def keypair():
-    return settings.BITTENSOR_WALLET().get_hotkey()
 
 
 @pytest_asyncio.fixture

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/conftest.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/conftest.py
@@ -8,11 +8,11 @@ from compute_horde.miner_client.base import AbstractTransport
 from compute_horde.mv_protocol import miner_requests
 from django.conf import settings
 
-from compute_horde_validator.validator.miner_client import MinerClient
 from compute_horde_validator.validator.models import (
     Miner,
     SyntheticJobBatch,
 )
+from compute_horde_validator.validator.synthetic_jobs.batch_run import BatchContext, MinerClient
 from compute_horde_validator.validator.tests.transport import MinerSimulationTransport
 
 
@@ -68,20 +68,12 @@ async def transport(miner_hotkey: str):
     return MinerSimulationTransport(miner_hotkey)
 
 
-@pytest_asyncio.fixture
-async def miner_client(
-    miner_hotkey: str, validator_hotkey: str, keypair, transport: AbstractTransport
-):
-    return MinerClient(
-        miner_address="ignore",
-        my_hotkey=validator_hotkey,
-        miner_hotkey=miner_hotkey,
-        miner_port=9999,
-        job_uuid=None,
-        batch_id=None,
-        keypair=keypair,
-        transport=transport,
-    )
+@pytest.fixture
+def create_simulation_miner_client(transport: AbstractTransport):
+    def _create(ctx: BatchContext, miner_hotkey: str):
+        return MinerClient(ctx=ctx, miner_hotkey=miner_hotkey, transport=transport)
+
+    return _create
 
 
 @pytest.fixture

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/mock_generator.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/mock_generator.py
@@ -41,7 +41,7 @@ class MockSyntheticJobGenerator(BaseSyntheticJobGenerator):
         return "mock"
 
 
-class TimeToookScoreMockSyntheticJobGenerator(MockSyntheticJobGenerator):
+class TimeTookScoreMockSyntheticJobGenerator(MockSyntheticJobGenerator):
     def verify(self, msg: V0JobFinishedRequest, time_took: float) -> tuple[bool, str, float]:
         return True, "mock", 1 / time_took
 
@@ -49,3 +49,8 @@ class TimeToookScoreMockSyntheticJobGenerator(MockSyntheticJobGenerator):
 class MockSyntheticJobGeneratorFactory(BaseSyntheticJobGeneratorFactory):
     async def create(self, executor_class: ExecutorClass) -> BaseSyntheticJobGenerator:
         return MockSyntheticJobGenerator()
+
+
+class TimeTookScoreMockSyntheticJobGeneratorFactory(BaseSyntheticJobGeneratorFactory):
+    async def create(self, executor_class: ExecutorClass) -> BaseSyntheticJobGenerator:
+        return TimeTookScoreMockSyntheticJobGenerator()

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/mock_generator.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/mock_generator.py
@@ -1,3 +1,5 @@
+import uuid
+
 from compute_horde.executor_class import ExecutorClass
 from compute_horde.mv_protocol.miner_requests import (
     V0JobFinishedRequest,
@@ -13,6 +15,9 @@ NOT_SCORED = 0.0
 
 
 class MockSyntheticJobGenerator(BaseSyntheticJobGenerator):
+    def __init__(self, _uuid: uuid.UUID):
+        self._uuid = _uuid
+
     async def ainit(self):
         pass
 
@@ -47,10 +52,15 @@ class TimeTookScoreMockSyntheticJobGenerator(MockSyntheticJobGenerator):
 
 
 class MockSyntheticJobGeneratorFactory(BaseSyntheticJobGeneratorFactory):
+    def __init__(self, uuids: list[uuid.UUID] = None):
+        self._uuids = uuids or []
+
     async def create(self, executor_class: ExecutorClass) -> BaseSyntheticJobGenerator:
-        return MockSyntheticJobGenerator()
+        _uuid = self._uuids.pop(0)
+        return MockSyntheticJobGenerator(_uuid)
 
 
-class TimeTookScoreMockSyntheticJobGeneratorFactory(BaseSyntheticJobGeneratorFactory):
+class TimeTookScoreMockSyntheticJobGeneratorFactory(MockSyntheticJobGeneratorFactory):
     async def create(self, executor_class: ExecutorClass) -> BaseSyntheticJobGenerator:
-        return TimeTookScoreMockSyntheticJobGenerator()
+        _uuid = self._uuids.pop(0)
+        return TimeTookScoreMockSyntheticJobGenerator(_uuid)

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/test_dance_incentives.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/test_dance_incentives.py
@@ -1,0 +1,144 @@
+import asyncio
+import json
+import uuid
+from unittest.mock import patch
+
+import bittensor
+import pytest
+from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS
+from compute_horde.mv_protocol import miner_requests
+from constance.test.unittest import override_config
+
+from compute_horde_validator.validator.miner_client import MinerClient
+from compute_horde_validator.validator.models import (
+    Miner,
+    SyntheticJob,
+    SyntheticJobBatch,
+)
+from compute_horde_validator.validator.synthetic_jobs.utils import execute_miner_synthetic_jobs
+from compute_horde_validator.validator.tests.transport import MinerSimulationTransport
+
+from .mock_generator import (
+    TimeTookScoreMockSyntheticJobGeneratorFactory,
+)
+
+MANIFEST_INCENTIVE_MULTIPLIER = 1.05
+MANIFEST_DANCE_RATIO_THRESHOLD = 1.4
+
+
+@pytest.fixture(autouse=True)
+def _override_config():
+    with override_config(
+        DYNAMIC_MANIFEST_SCORE_MULTIPLIER=MANIFEST_INCENTIVE_MULTIPLIER,
+        DYNAMIC_MANIFEST_DANCE_RATIO_THRESHOLD=MANIFEST_DANCE_RATIO_THRESHOLD,
+    ):
+        yield
+
+
+@patch(
+    "compute_horde_validator.validator.synthetic_jobs.generator.current.synthetic_job_generator_factory",
+    TimeTookScoreMockSyntheticJobGeneratorFactory(),
+)
+@pytest.mark.asyncio
+@pytest.mark.django_db(databases=["default", "default_alias"], transaction=True)
+@pytest.mark.parametrize(
+    "curr_online_executor_count,prev_online_executor_count,expected_multiplier",
+    [
+        # None -> 3
+        (3, None, MANIFEST_INCENTIVE_MULTIPLIER),
+        # 0 -> 3 - e.g. all executors failed to start cause docker images were not cached
+        (3, 0, MANIFEST_INCENTIVE_MULTIPLIER),
+        # 10 -> below ratio
+        (10, int(10 * MANIFEST_DANCE_RATIO_THRESHOLD) - 1, 1),
+        # below ratio -> 10
+        (int(10 * MANIFEST_DANCE_RATIO_THRESHOLD) - 1, 10, 1),
+        # 10 -> above ratio
+        (
+            int(10 * MANIFEST_DANCE_RATIO_THRESHOLD) + 1,
+            10,
+            MANIFEST_INCENTIVE_MULTIPLIER,
+        ),
+        # above ratio -> 10
+        (
+            10,
+            int(10 * MANIFEST_DANCE_RATIO_THRESHOLD) + 1,
+            MANIFEST_INCENTIVE_MULTIPLIER,
+        ),
+    ],
+)
+async def test_manifest_dance_incentives(
+    curr_online_executor_count: int,
+    prev_online_executor_count: int,
+    expected_multiplier: float,
+    miner: Miner,
+    batch: SyntheticJobBatch,
+    miner_hotkey: str,
+    miner_axon_info: bittensor.AxonInfo,
+    miner_client: MinerClient,
+    transport: MinerSimulationTransport,
+    override_weights_version_v2,
+):
+    job_uuids = [uuid.uuid4() for _ in range(curr_online_executor_count)]
+
+    def make_uuid_generator():
+        uuids = job_uuids.copy()
+
+        def _generate():
+            return uuids.pop(0)
+
+        return _generate
+
+    manifest_message = miner_requests.V0ExecutorManifestRequest(
+        manifest=miner_requests.ExecutorManifest(
+            executor_classes=[
+                miner_requests.ExecutorClassManifest(
+                    executor_class=DEFAULT_EXECUTOR_CLASS, count=curr_online_executor_count
+                )
+            ]
+        )
+    ).model_dump_json()
+    await transport.add_message(manifest_message, send_before=1)
+
+    async def add_job_messages(request_class, send_before=1, **kwargs):
+        for job_uuid in job_uuids:
+            msg = request_class(
+                job_uuid=str(job_uuid),
+                **kwargs,
+            ).model_dump_json()
+            await transport.add_message(msg, send_before=send_before)
+
+    await add_job_messages(miner_requests.V0ExecutorReadyRequest, send_before=1)
+    await add_job_messages(miner_requests.V0AcceptJobRequest, send_before=2)
+    await add_job_messages(
+        miner_requests.V0JobFinishedRequest,
+        send_before=0,
+        docker_process_stdout="",
+        docker_process_stderr="",
+    )
+
+    await asyncio.wait_for(
+        execute_miner_synthetic_jobs(
+            batch.pk,
+            miner.pk,
+            miner_hotkey,
+            miner_axon_info,
+            prev_online_executor_count,
+            miner_client,
+            generate_job_uuid=make_uuid_generator(),
+        ),
+        timeout=1,
+    )
+
+    job_finished_messages = miner_client.transport.sent[-len(job_uuids) :]
+
+    for msg in job_finished_messages:
+        receipt = json.loads(msg)
+
+        job_uuid = receipt["payload"]["job_uuid"]
+
+        time_took_us = receipt["payload"]["time_took_us"]
+        time_took = time_took_us / 1_000_000
+
+        job = await SyntheticJob.objects.aget(job_uuid=job_uuid)
+
+        assert abs(job.score * time_took - expected_multiplier) < 0.0001

--- a/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/test_single_miner.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_synthetic_jobs/test_single_miner.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import bittensor
 import pytest
 from asgiref.sync import sync_to_async
-from compute_horde.transport import AbstractTransport
 from pytest_mock import MockerFixture
 
 from compute_horde_validator.validator.models import (
@@ -14,11 +13,7 @@ from compute_horde_validator.validator.models import (
     SyntheticJob,
     SystemEvent,
 )
-from compute_horde_validator.validator.synthetic_jobs.batch_run import (
-    BatchContext,
-    MinerClient,
-    execute_synthetic_batch_run,
-)
+from compute_horde_validator.validator.synthetic_jobs.batch_run import execute_synthetic_batch_run
 from compute_horde_validator.validator.tests.transport import MinerSimulationTransport
 
 from ..helpers import check_system_events
@@ -40,14 +35,6 @@ def _patch_generator_factory(mocker: MockerFixture, job_uuid: uuid.UUID):
         "compute_horde_validator.validator.synthetic_jobs.generator.current.synthetic_job_generator_factory",
         MockSyntheticJobGeneratorFactory(uuids=[job_uuid]),
     )
-
-
-@pytest.fixture
-def create_simulation_miner_client(transport: AbstractTransport):
-    def _create(ctx: BatchContext, miner_hotkey: str):
-        return MinerClient(ctx=ctx, miner_hotkey=miner_hotkey, transport=transport)
-
-    return _create
 
 
 async def test_execute_miner_synthetic_jobs_success(

--- a/validator/app/src/compute_horde_validator/validator/tests/transport.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/transport.py
@@ -1,0 +1,53 @@
+import asyncio
+import logging
+from collections import deque
+
+from compute_horde.miner_client.base import AbstractTransport
+
+
+class MinerSimulationTransport(AbstractTransport):
+    def __init__(self, name: str, *args, **kwargs):
+        super().__init__(name, *args, **kwargs)
+        self.received: list[str] = []
+        self.sent = []
+        self.remaining = 0
+        self.to_receive: deque[tuple[int, str]] = deque()
+        self.ready_to_receive = asyncio.Event()
+        self.ready_to_receive.set()
+        self.logger = logging.getLogger(f"transport.{name}")
+
+    async def start(self): ...
+
+    async def stop(self): ...
+
+    async def send(self, message):
+        self.logger.debug(f"Sending message: {message}")
+
+        self.sent.append(message)
+
+        self.remaining = max(0, self.remaining - 1)
+        if self.remaining == 0:
+            self.ready_to_receive.set()
+
+    async def receive(self):
+        if not self.to_receive:
+            self.logger.debug("No more messages to receive")
+            await asyncio.Future()
+
+        await self.ready_to_receive.wait()
+
+        self.remaining, message = self.to_receive.popleft()
+        self.ready_to_receive.clear()
+
+        self.received.append(message)
+
+        self.logger.debug(f"Received message: {message}")
+
+        return message
+
+    async def add_message(self, message, receive_before=0):
+        if not self.to_receive:
+            self.remaining = receive_before
+            self.ready_to_receive.clear()
+
+        self.to_receive.append((receive_before, message))

--- a/validator/app/src/compute_horde_validator/validator/tests/transport.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/transport.py
@@ -50,7 +50,9 @@ class MinerSimulationTransport(AbstractTransport):
 
         return message
 
-    async def add_message(self, message: str, send_before: int = 0, sleep_before: int = 0) -> None:
+    async def add_message(
+        self, message: str, send_before: int = 0, sleep_before: float = 0
+    ) -> None:
         """
         Add a message to be received after a certain number of sent messages.
         Receives the message immediately if send_before is 0.


### PR DESCRIPTION
This PR introduces a drop-in integration alternative for all tests that are currently in `test_utils.py`, except `test_create_and_run_synthetic_job_batch`. Integration tests replacing the latter will probably go in a separate PR (there is an idea to test multiple miners at once there) to keep this one manageable.
 