### PR TITLE
Add django-less miner client in library

### DIFF
--- a/compute_horde/compute_horde/miner_client/base.py
+++ b/compute_horde/compute_horde/miner_client/base.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 ErrorCallback: TypeAlias = Callable[[str], Awaitable[None]]
 
 
-class AbstractMinerClient(abc.ABC):
+class AbstractMinerClient(metaclass=abc.ABCMeta):
     def __init__(self, miner_name: str, transport: AbstractTransport):
         self.miner_name = miner_name
         self.read_messages_task: asyncio.Task | None = None
@@ -48,6 +48,7 @@ class AbstractMinerClient(abc.ABC):
 
     async def __aenter__(self):
         await self.connect()
+        return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()

--- a/compute_horde/compute_horde/miner_client/organic.py
+++ b/compute_horde/compute_horde/miner_client/organic.py
@@ -1,0 +1,241 @@
+import asyncio
+import datetime
+import logging
+import time
+from functools import cached_property
+
+import bittensor
+
+from compute_horde.base_requests import BaseRequest
+from compute_horde.executor_class import ExecutorClass
+from compute_horde.miner_client.base import AbstractMinerClient, UnsupportedMessageReceived
+from compute_horde.mv_protocol import miner_requests, validator_requests
+from compute_horde.mv_protocol.miner_requests import (
+    BaseMinerRequest,
+    UnauthorizedError,
+    V0AcceptJobRequest,
+    V0DeclineJobRequest,
+    V0ExecutorFailedRequest,
+    V0ExecutorManifestRequest,
+    V0ExecutorReadyRequest,
+    V0JobFailedRequest,
+    V0JobFinishedRequest,
+    V0MachineSpecsRequest,
+)
+from compute_horde.mv_protocol.validator_requests import (
+    AuthenticationPayload,
+    JobFinishedReceiptPayload,
+    JobStartedReceiptPayload,
+    V0AuthenticateRequest,
+    V0JobFinishedReceiptRequest,
+    V0JobStartedReceiptRequest,
+)
+from compute_horde.transport import AbstractTransport, WSTransport
+from compute_horde.utils import MachineSpecs
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: write docs at class level and method level
+class OrganicMinerClient(AbstractMinerClient):
+    def __init__(
+        self,
+        miner_hotkey: str,
+        miner_address: str,
+        miner_port: int,
+        job_uuid: str,
+        my_keypair: bittensor.Keypair,
+        transport: AbstractTransport | None = None,
+    ) -> None:
+        self.job_uuid = job_uuid
+
+        self.miner_hotkey = miner_hotkey
+        self.miner_address = miner_address
+        self.miner_port = miner_port
+        self.my_keypair = my_keypair
+
+        loop = asyncio.get_running_loop()
+        self.miner_manifest = loop.create_future()
+        self.online_executor_count = 0
+
+        # for waiting on miner responses (replaces JobState)
+        self.miner_ready_or_declining_future = loop.create_future()
+        self.miner_ready_or_declining_timestamp: int = 0
+        self.miner_finished_or_failed_future = loop.create_future()
+        self.miner_finished_or_failed_timestamp: int = 0
+        self.miner_machine_specs: MachineSpecs | None = None  # what should we do with this???
+
+        name = f"{miner_hotkey}({miner_address}:{miner_port})"
+        transport = transport or WSTransport(name, self.miner_url())
+        super().__init__(name, transport)
+
+    @cached_property
+    def my_hotkey(self) -> str:
+        return self.my_keypair.ss58_address
+
+    def miner_url(self) -> str:
+        return (
+            f"ws://{self.miner_address}:{self.miner_port}/v0.1/validator_interface/{self.my_hotkey}"
+        )
+
+    def accepted_request_type(self) -> type[BaseRequest]:
+        return BaseMinerRequest
+
+    def incoming_generic_error_class(self) -> type[BaseRequest]:
+        return miner_requests.GenericError
+
+    def outgoing_generic_error_class(self) -> type[BaseRequest]:
+        return validator_requests.GenericError
+
+    async def notify_generic_error(self, msg: BaseRequest) -> None:
+        pass
+
+    async def notify_unauthorized_error(self, msg: UnauthorizedError) -> None:
+        pass
+
+    async def notify_receipt_failure(self, comment: str) -> None:
+        pass
+
+    async def job_error_event_callback(self, msg: str) -> None:
+        pass
+
+    async def handle_manifest_request(self, msg: V0ExecutorManifestRequest) -> None:
+        try:
+            self.miner_manifest.set_result(msg.manifest)
+        except asyncio.InvalidStateError:
+            logger.warning(f"Received manifest from {msg} but future was already set")
+
+    async def handle_machine_specs_request(self, msg: V0MachineSpecsRequest) -> None:
+        self.miner_machine_specs = msg.specs
+
+    async def handle_message(self, msg: BaseRequest) -> None:
+        if isinstance(msg, self.incoming_generic_error_class()):
+            logger.warning(
+                f"Received error message from miner {self.miner_name}: {msg.model_dump_json()}"
+            )
+            await self.notify_generic_error(msg)
+            return
+        elif isinstance(msg, UnauthorizedError):
+            logger.error(f"Unauthorized in {self.miner_name}: {msg.code}, details: {msg.details}")
+            await self.notify_unauthorized_error(msg)
+            return
+        elif isinstance(msg, V0ExecutorManifestRequest):
+            await self.handle_manifest_request(msg)
+            return
+
+        if isinstance(msg, V0AcceptJobRequest):
+            logger.info(f"Miner {self.miner_name} accepted job")
+        elif isinstance(
+            msg, V0DeclineJobRequest | V0ExecutorFailedRequest | V0ExecutorReadyRequest
+        ):
+            try:
+                self.miner_ready_or_declining_future.set_result(msg)
+                self.miner_ready_or_declining_timestamp = time.time()
+            except asyncio.InvalidStateError:
+                logger.warning(f"Received {msg} from {self.miner_name} but future was already set")
+        elif isinstance(msg, V0JobFailedRequest | V0JobFinishedRequest):
+            try:
+                self.miner_finished_or_failed_future.set_result(msg)
+                self.miner_finished_or_failed_timestamp = time.time()
+            except asyncio.InvalidStateError:
+                logger.warning(f"Received {msg} from {self.miner_name} but future was already set")
+        elif isinstance(msg, V0MachineSpecsRequest):
+            await self.handle_machine_specs_request(msg)
+        else:
+            raise UnsupportedMessageReceived(msg)
+
+    def generate_authentication_message(self) -> V0AuthenticateRequest:
+        payload = AuthenticationPayload(
+            validator_hotkey=self.my_hotkey,
+            miner_hotkey=self.miner_hotkey,
+            timestamp=int(time.time()),
+        )
+        return V0AuthenticateRequest(
+            payload=payload, signature=f"0x{self.my_keypair.sign(payload.blob_for_signing()).hex()}"
+        )
+
+    def generate_job_started_receipt_message(
+        self,
+        executor_class: ExecutorClass,
+        accepted_timestamp: float,
+        max_timeout: int,
+    ) -> V0JobStartedReceiptRequest:
+        time_accepted = datetime.datetime.fromtimestamp(accepted_timestamp, datetime.UTC)
+        receipt_payload = JobStartedReceiptPayload(
+            job_uuid=self.job_uuid,
+            miner_hotkey=self.miner_hotkey,
+            validator_hotkey=self.my_hotkey,
+            executor_class=executor_class,
+            time_accepted=time_accepted,
+            max_timeout=max_timeout,
+        )
+        return V0JobStartedReceiptRequest(
+            payload=receipt_payload,
+            signature=f"0x{self.my_keypair.sign(receipt_payload.blob_for_signing()).hex()}",
+        )
+
+    async def send_job_started_receipt_message(
+        self,
+        executor_class: ExecutorClass,
+        accepted_timestamp: float,
+        max_timeout: int,
+    ) -> None:
+        try:
+            receipt_message = self.generate_job_started_receipt_message(
+                executor_class,
+                accepted_timestamp,
+                max_timeout,
+            )
+            await self.send_model(
+                receipt_message,
+                error_event_callback=self.job_error_event_callback,
+            )
+            logger.debug(f"Sent job started receipt for {self.job_uuid}")
+        except Exception as e:
+            comment = f"Failed to send job started receipt to miner {self.miner_name} for job {self.job_uuid}: {e}"
+            logger.warning(comment)
+            await self.notify_receipt_failure(comment)
+
+    def generate_job_finished_receipt_message(
+        self,
+        started_timestamp: float,
+        time_took_seconds: float,
+        score: float,
+    ) -> V0JobFinishedReceiptRequest:
+        time_started = datetime.datetime.fromtimestamp(started_timestamp, datetime.UTC)
+        receipt_payload = JobFinishedReceiptPayload(
+            job_uuid=self.job_uuid,
+            miner_hotkey=self.miner_hotkey,
+            validator_hotkey=self.my_hotkey,
+            time_started=time_started,
+            time_took_us=int(time_took_seconds * 1_000_000),
+            score_str=f"{score:.6f}",
+        )
+        return V0JobFinishedReceiptRequest(
+            payload=receipt_payload,
+            signature=f"0x{self.my_keypair.sign(receipt_payload.blob_for_signing()).hex()}",
+        )
+
+    async def send_job_finished_receipt_message(
+        self,
+        started_timestamp: float,
+        time_took_seconds: float,
+        score: float,
+    ) -> None:
+        try:
+            receipt_message = self.generate_job_finished_receipt_message(
+                started_timestamp, time_took_seconds, score
+            )
+            await self.send_model(
+                receipt_message,
+                error_event_callback=self.job_error_event_callback,
+            )
+            logger.debug(f"Sent job finished receipt for {self.job_uuid}")
+        except Exception as e:
+            comment = f"Failed to send job finished receipt to miner {self.miner_name} for job {self.job_uuid}: {e}"
+            logger.warning(comment)
+            await self.notify_receipt_failure(comment)
+
+    async def connect(self) -> None:
+        await super().connect()
+        await self.transport.send(self.generate_authentication_message().model_dump_json())

--- a/compute_horde/compute_horde/miner_client/organic.py
+++ b/compute_horde/compute_horde/miner_client/organic.py
@@ -312,11 +312,6 @@ class OrganicJobError(Exception):
 @dataclass
 class OrganicJobDetails:
     job_uuid: str
-
-    miner_hotkey: str
-    miner_address: str
-    miner_port: int
-
     executor_class: ExecutorClass = ExecutorClass.spin_up_4min__gpu_24gb
     docker_image: str | None = None
     raw_script: str | None = None
@@ -332,25 +327,19 @@ class OrganicJobDetails:
 
 
 async def run_organic_job(
+    client: OrganicMinerClient,
     job_details: OrganicJobDetails,
-    my_keypair: bittensor.Keypair,
     wait_timeout: int = 300,
 ):
     """
     Run an organic job. This is a simpler way to use OrganicMinerClient.
 
+    :param client: the organic miner client
     :param job_details: details specific to the job that needs to be run
-    :param my_keypair: the hotkey keypair of the validator
     :param wait_timeout: maximum timeout for waiting for miner responses
     :return: standard out and standard error of the job container
     """
-    client = OrganicMinerClient(
-        miner_hotkey=job_details.miner_hotkey,
-        miner_address=job_details.miner_address,
-        miner_port=job_details.miner_port,
-        job_uuid=job_details.job_uuid,
-        my_keypair=my_keypair,
-    )
+    assert client.job_uuid == job_details.job_uuid
 
     async with contextlib.AsyncExitStack() as exit_stack:
         try:

--- a/compute_horde/compute_horde/miner_client/organic.py
+++ b/compute_horde/compute_horde/miner_client/organic.py
@@ -318,7 +318,6 @@ class OrganicJobDetails:
     miner_port: int
 
     executor_class: ExecutorClass = ExecutorClass.spin_up_4min__gpu_24gb
-    base_docker_image_name: str | None = None
     docker_image: str | None = None
     raw_script: str | None = None
     docker_run_options_preset: Literal["nvidia_all", "none"] = "nvidia_all"
@@ -328,9 +327,6 @@ class OrganicJobDetails:
     output: OutputUpload | None = None
 
     def __post_init__(self):
-        if self.base_docker_image_name is None:
-            self.base_docker_image_name = self.docker_image
-
         if (self.docker_image, self.raw_script) == (None, None):
             raise ValueError("At least of of `docker_image` or `raw_script` must be not None")
 
@@ -368,7 +364,7 @@ async def run_organic_job(
             V0InitialJobRequest(
                 job_uuid=job_details.job_uuid,
                 executor_class=job_details.executor_class,
-                base_docker_image_name=job_details.base_docker_image_name,
+                base_docker_image_name=job_details.docker_image,
                 timeout_seconds=job_details.total_job_timeout,
                 volume_type=job_details.volume.volume_type if job_details.volume else None,
             ),

--- a/compute_horde/compute_horde/miner_client/organic.py
+++ b/compute_horde/compute_horde/miner_client/organic.py
@@ -161,8 +161,9 @@ class OrganicMinerClient(AbstractMinerClient):
 
         if getattr(msg, "job_uuid", self.job_uuid) != self.job_uuid:
             logger.warning(
-                f"Received msg from {self.miner_name} for a different job (expected {self.job_uuid=}): {msg}"
+                f"Received msg from {self.miner_name} for a different job (expected job {self.job_uuid}, got job {msg.job_uuid}): {msg}"
             )
+            return
 
         if isinstance(msg, V0AcceptJobRequest):
             logger.info(f"Miner {self.miner_name} accepted job")

--- a/compute_horde/compute_horde/miner_client/organic.py
+++ b/compute_horde/compute_horde/miner_client/organic.py
@@ -159,9 +159,9 @@ class OrganicMinerClient(AbstractMinerClient):
             await self.handle_manifest_request(msg)
             return
 
-        if getattr(msg, "job_uuid", self.job_uuid) != self.job_uuid:
+        if (received_job_uuid := getattr(msg, "job_uuid", self.job_uuid)) != self.job_uuid:
             logger.warning(
-                f"Received msg from {self.miner_name} for a different job (expected job {self.job_uuid}, got job {msg.job_uuid}): {msg}"
+                f"Received msg from {self.miner_name} for a different job (expected job {self.job_uuid}, got job {received_job_uuid}): {msg}"
             )
             return
 
@@ -172,13 +172,13 @@ class OrganicMinerClient(AbstractMinerClient):
         ):
             try:
                 self.miner_ready_or_declining_future.set_result(msg)
-                self.miner_ready_or_declining_timestamp = time.time()
+                self.miner_ready_or_declining_timestamp = int(time.time())
             except asyncio.InvalidStateError:
                 logger.warning(f"Received {msg} from {self.miner_name} but future was already set")
         elif isinstance(msg, V0JobFailedRequest | V0JobFinishedRequest):
             try:
                 self.miner_finished_or_failed_future.set_result(msg)
-                self.miner_finished_or_failed_timestamp = time.time()
+                self.miner_finished_or_failed_timestamp = int(time.time())
             except asyncio.InvalidStateError:
                 logger.warning(f"Received {msg} from {self.miner_name} but future was already set")
         elif isinstance(msg, V0MachineSpecsRequest):

--- a/compute_horde/compute_horde/transport/stub.py
+++ b/compute_horde/compute_horde/transport/stub.py
@@ -11,7 +11,7 @@ class StubTransport(AbstractTransport):
 
     def __init__(self, name: str, messages: list[str], *args, **kwargs):
         self.sent: list[str] = []
-        self.messages = messages
+        self.messages = iter(messages)
         self.sent_messages: list[str] = []
 
     async def start(self): ...

--- a/compute_horde/compute_horde/utils.py
+++ b/compute_horde/compute_horde/utils.py
@@ -57,3 +57,17 @@ def _json_dumps_default(obj):
         return obj.isoformat()
 
     raise TypeError
+
+
+class Timer:
+    def __init__(self, timeout=None):
+        self.start_time = datetime.datetime.now()
+        self.timeout = timeout
+
+    def passed_time(self):
+        return (datetime.datetime.now() - self.start_time).total_seconds()
+
+    def time_left(self):
+        if self.timeout is None:
+            raise ValueError("timeout was not specified")
+        return self.timeout - self.passed_time()

--- a/compute_horde/noxfile.py
+++ b/compute_horde/noxfile.py
@@ -36,7 +36,7 @@ def lint(session: nox.Session):
     install(session, "lint")
     session.run("ruff", "check", "--diff", ".")
     session.run("codespell", ".", "--skip='*.lock'")
-    session.run("ruff", "format", ".")
+    session.run("ruff", "format", "--diff", ".")
 
 
 @nox.session(python=PYTHON_VERSION)

--- a/compute_horde/tests/test_organic_miner_client.py
+++ b/compute_horde/tests/test_organic_miner_client.py
@@ -1,0 +1,143 @@
+import uuid
+
+import bittensor
+import pytest
+
+from compute_horde.base_requests import BaseRequest
+from compute_horde.miner_client.organic import OrganicMinerClient
+from compute_horde.mv_protocol.miner_requests import (
+    V0DeclineJobRequest,
+    V0ExecutorFailedRequest,
+    V0ExecutorReadyRequest,
+    V0JobFailedRequest,
+    V0JobFinishedRequest,
+)
+from compute_horde.transport import StubTransport
+
+JOB_UUID = "b4793a02-33a2-4a49-b4e2-4a7b903847e7"
+
+
+def get_miner_client(
+    keypair: bittensor.Keypair,
+    messages: list[BaseRequest] | None = None,
+) -> OrganicMinerClient:
+    transport = StubTransport("stub", messages or [])
+    client = OrganicMinerClient(
+        miner_hotkey="mock",
+        miner_address="0.0.0.0",
+        miner_port=1234,
+        job_uuid=JOB_UUID,
+        my_keypair=keypair,
+        transport=transport,
+    )
+    return client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_msg,final_msg",
+    [
+        (V0DeclineJobRequest(job_uuid=JOB_UUID), None),
+        (V0ExecutorFailedRequest(job_uuid=JOB_UUID), None),
+        (
+            V0ExecutorReadyRequest(job_uuid=JOB_UUID),
+            V0JobFailedRequest(
+                job_uuid=JOB_UUID,
+                docker_process_exit_status=1,
+                docker_process_stdout="stdout",
+                docker_process_stderr="stderr",
+            ),
+        ),
+        (
+            V0ExecutorReadyRequest(job_uuid=JOB_UUID),
+            V0JobFinishedRequest(
+                job_uuid=JOB_UUID,
+                docker_process_stdout="stdout",
+                docker_process_stderr="stderr",
+            ),
+        ),
+    ],
+)
+async def test_organic_miner_client__futures__properly_set(initial_msg, final_msg, keypair):
+    miner_client = get_miner_client(keypair)
+
+    assert not miner_client.miner_ready_or_declining_future.done()
+    assert miner_client.miner_ready_or_declining_timestamp == 0
+
+    await miner_client.handle_message(initial_msg)
+
+    assert miner_client.miner_ready_or_declining_future.done()
+    assert miner_client.miner_ready_or_declining_timestamp != 0
+    assert await miner_client.miner_ready_or_declining_future == initial_msg
+
+    # should set only once
+    set_time = miner_client.miner_ready_or_declining_timestamp
+    await miner_client.handle_message(initial_msg)
+    assert miner_client.miner_ready_or_declining_timestamp == set_time
+
+    if final_msg is None:
+        return
+
+    assert not miner_client.miner_finished_or_failed_future.done()
+    assert miner_client.miner_finished_or_failed_timestamp == 0
+
+    await miner_client.handle_message(final_msg)
+
+    assert miner_client.miner_finished_or_failed_future.done()
+    assert miner_client.miner_finished_or_failed_timestamp != 0
+    assert await miner_client.miner_finished_or_failed_future == final_msg
+
+    # should set only once
+    set_time = miner_client.miner_finished_or_failed_timestamp
+    await miner_client.handle_message(final_msg)
+    assert miner_client.miner_finished_or_failed_timestamp == set_time
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_msg",
+    [
+        V0DeclineJobRequest(job_uuid=str(uuid.uuid4())),
+        V0ExecutorFailedRequest(job_uuid=str(uuid.uuid4())),
+        V0ExecutorReadyRequest(job_uuid=str(uuid.uuid4())),
+    ],
+)
+async def test_organic_miner_client__skip_different_job__initial_future(initial_msg, keypair):
+    miner_client = get_miner_client(keypair)
+
+    assert not miner_client.miner_ready_or_declining_future.done()
+    assert miner_client.miner_ready_or_declining_timestamp == 0
+
+    await miner_client.handle_message(initial_msg)
+
+    assert not miner_client.miner_ready_or_declining_future.done()
+    assert miner_client.miner_ready_or_declining_timestamp == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "final_msg",
+    [
+        V0JobFailedRequest(
+            job_uuid=str(uuid.uuid4()),
+            docker_process_exit_status=1,
+            docker_process_stdout="stdout",
+            docker_process_stderr="stderr",
+        ),
+        V0JobFinishedRequest(
+            job_uuid=str(uuid.uuid4()),
+            docker_process_stdout="stdout",
+            docker_process_stderr="stderr",
+        ),
+    ],
+)
+async def test_organic_miner_client__skip_different_job__final_future(final_msg, keypair):
+    miner_client = get_miner_client(keypair)
+
+    assert not miner_client.miner_finished_or_failed_future.done()
+    assert miner_client.miner_finished_or_failed_timestamp == 0
+
+    await miner_client.handle_message(final_msg)
+
+    assert not miner_client.miner_finished_or_failed_future.done()
+    assert miner_client.miner_finished_or_failed_timestamp == 0

--- a/compute_horde/tests/test_run_organic_job.py
+++ b/compute_horde/tests/test_run_organic_job.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from compute_horde.miner_client.organic import (
@@ -31,53 +29,34 @@ class MinerStubTransport(StubTransport):
         self.sent_models.append(BaseValidatorRequest.parse(message))
 
 
-class MockOrganicMinerClient(OrganicMinerClient):
-    def __init__(self, *args, **kwargs):
-        kwargs["transport"] = MinerStubTransport(
-            "mock",
-            [
-                V0ExecutorReadyRequest(job_uuid=JOB_UUID).model_dump_json(),
-                V0JobFinishedRequest(
-                    job_uuid=JOB_UUID,
-                    docker_process_stdout="stdout",
-                    docker_process_stderr="stderr",
-                ).model_dump_json(),
-            ],
-        )
-        super().__init__(*args, **kwargs)
-
-
-@pytest.fixture
-def mocked_organic_miner_client():
-    with patch("compute_horde.miner_client.organic.OrganicMinerClient") as MockedClient:
-        MockedClient.instance = None
-
-        def side_effect(*args, **kwargs):
-            if MockedClient.instance is not None:
-                raise RuntimeError("You can create only single instance of mocked MinerClient")
-            MockedClient.instance = MockOrganicMinerClient(*args, **kwargs)
-            return MockedClient.instance
-
-        MockedClient.side_effect = side_effect
-        yield MockedClient
-
-
 @pytest.mark.asyncio
-async def test_run_organic_job__success(mocked_organic_miner_client, keypair):
-    job_details = OrganicJobDetails(
-        job_uuid=JOB_UUID,
+async def test_run_organic_job__success(keypair):
+    mock_transport = MinerStubTransport(
+        "mock",
+        [
+            V0ExecutorReadyRequest(job_uuid=JOB_UUID).model_dump_json(),
+            V0JobFinishedRequest(
+                job_uuid=JOB_UUID,
+                docker_process_stdout="stdout",
+                docker_process_stderr="stderr",
+            ).model_dump_json(),
+        ],
+    )
+    client = OrganicMinerClient(
         miner_hotkey="mock",
         miner_address="0.0.0.0",
         miner_port=1234,
-        docker_image="mock",
+        job_uuid=JOB_UUID,
+        my_keypair=keypair,
+        transport=mock_transport,
     )
-    stdout, stderr = await run_organic_job(job_details, keypair, wait_timeout=2)
+    job_details = OrganicJobDetails(job_uuid=JOB_UUID, docker_image="mock")
+    stdout, stderr = await run_organic_job(client, job_details, wait_timeout=2)
 
     assert stdout == "stdout"
     assert stderr == "stderr"
 
-    sent_models = mocked_organic_miner_client.instance.transport.sent_models
-    sent_models_types = [type(model) for model in sent_models]
+    sent_models_types = [type(model) for model in mock_transport.sent_models]
     assert sent_models_types == [
         V0AuthenticateRequest,
         V0InitialJobRequest,

--- a/compute_horde/tests/test_run_organic_job.py
+++ b/compute_horde/tests/test_run_organic_job.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+import pytest
+
+from compute_horde.miner_client.organic import (
+    OrganicJobDetails,
+    OrganicMinerClient,
+    run_organic_job,
+)
+from compute_horde.mv_protocol.miner_requests import V0ExecutorReadyRequest, V0JobFinishedRequest
+from compute_horde.mv_protocol.validator_requests import (
+    BaseValidatorRequest,
+    V0AuthenticateRequest,
+    V0InitialJobRequest,
+    V0JobFinishedReceiptRequest,
+    V0JobRequest,
+    V0JobStartedReceiptRequest,
+)
+from compute_horde.transport import StubTransport
+
+JOB_UUID = "b4793a02-33a2-4a49-b4e2-4a7b903847e7"
+
+
+class MinerStubTransport(StubTransport):
+    def __init__(self, name: str, messages: list[str], *args, **kwargs):
+        super().__init__(name, messages, *args, **kwargs)
+        self.sent_models = []
+
+    async def send(self, message):
+        await super().send(message)
+        self.sent_models.append(BaseValidatorRequest.parse(message))
+
+
+class MockOrganicMinerClient(OrganicMinerClient):
+    def __init__(self, *args, **kwargs):
+        kwargs["transport"] = MinerStubTransport(
+            "mock",
+            [
+                V0ExecutorReadyRequest(job_uuid=JOB_UUID).model_dump_json(),
+                V0JobFinishedRequest(
+                    job_uuid=JOB_UUID,
+                    docker_process_stdout="stdout",
+                    docker_process_stderr="stderr",
+                ).model_dump_json(),
+            ],
+        )
+        super().__init__(*args, **kwargs)
+
+
+@pytest.fixture
+def mocked_organic_miner_client():
+    with patch("compute_horde.miner_client.organic.OrganicMinerClient") as MockedClient:
+        MockedClient.instance = None
+
+        def side_effect(*args, **kwargs):
+            if MockedClient.instance is not None:
+                raise RuntimeError("You can create only single instance of mocked MinerClient")
+            MockedClient.instance = MockOrganicMinerClient(*args, **kwargs)
+            return MockedClient.instance
+
+        MockedClient.side_effect = side_effect
+        yield MockedClient
+
+
+@pytest.mark.asyncio
+async def test_run_organic_job__success(mocked_organic_miner_client, keypair):
+    job_details = OrganicJobDetails(
+        job_uuid=JOB_UUID,
+        miner_hotkey="mock",
+        miner_address="0.0.0.0",
+        miner_port=1234,
+        docker_image="mock",
+    )
+    stdout, stderr = await run_organic_job(job_details, keypair, wait_timeout=2)
+
+    assert stdout == "stdout"
+    assert stderr == "stderr"
+
+    sent_models = mocked_organic_miner_client.instance.transport.sent_models
+    sent_models_types = [type(model) for model in sent_models]
+    assert sent_models_types == [
+        V0AuthenticateRequest,
+        V0InitialJobRequest,
+        V0JobStartedReceiptRequest,
+        V0JobRequest,
+        V0JobFinishedReceiptRequest,
+    ]
+
+
+# TODO:
+#   - unhappy path
+#       - connection error
+#       - initial_response timeout
+#       - send error event callback
+#       - declined
+#       - executor failed
+#       - full_response timeout
+#       - job failed

--- a/compute_horde/tests/test_utils.py
+++ b/compute_horde/tests/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+from freezegun import freeze_time
+
+from compute_horde.utils import Timer
+
+
+def test_timer_none():
+    with freeze_time("2024-01-01 00:00:00"):
+        timer = Timer()
+        with pytest.raises(ValueError):
+            timer.time_left()
+
+
+def test_timer_timeout():
+    with freeze_time("2024-01-01 00:00:00") as frozen_time:
+        timer = Timer(timeout=300)
+        frozen_time.move_to("2024-01-01 00:00:30")
+        assert timer.passed_time() == 30.0
+        assert timer.time_left() == 270.0

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_client.py
@@ -1,36 +1,8 @@
-import asyncio
-import datetime
 import logging
-import time
-from functools import cached_property
 
-import bittensor
 from compute_horde.base_requests import BaseRequest
-from compute_horde.executor_class import ExecutorClass
-from compute_horde.miner_client.base import AbstractMinerClient, UnsupportedMessageReceived
-from compute_horde.mv_protocol import miner_requests, validator_requests
-from compute_horde.mv_protocol.miner_requests import (
-    BaseMinerRequest,
-    UnauthorizedError,
-    V0AcceptJobRequest,
-    V0DeclineJobRequest,
-    V0ExecutorFailedRequest,
-    V0ExecutorManifestRequest,
-    V0ExecutorReadyRequest,
-    V0JobFailedRequest,
-    V0JobFinishedRequest,
-    V0MachineSpecsRequest,
-)
-from compute_horde.mv_protocol.validator_requests import (
-    AuthenticationPayload,
-    JobFinishedReceiptPayload,
-    JobStartedReceiptPayload,
-    V0AuthenticateRequest,
-    V0JobFinishedReceiptRequest,
-    V0JobStartedReceiptRequest,
-)
-from compute_horde.transport import AbstractTransport, WSTransport
-from compute_horde.utils import MachineSpecs
+from compute_horde.miner_client.organic import OrganicMinerClient
+from compute_horde.mv_protocol.miner_requests import UnauthorizedError
 from django.conf import settings
 
 from compute_horde_validator.validator.models import SystemEvent
@@ -38,58 +10,8 @@ from compute_horde_validator.validator.models import SystemEvent
 logger = logging.getLogger(__name__)
 
 
-class MinerClient(AbstractMinerClient):
-    def __init__(
-        self,
-        miner_hotkey: str,
-        miner_address: str,
-        miner_port: int,
-        job_uuid: str,
-        my_keypair: bittensor.Keypair,
-        transport: AbstractTransport | None = None,
-    ) -> None:
-        self.job_uuid = job_uuid
-
-        self.miner_hotkey = miner_hotkey
-        self.miner_address = miner_address
-        self.miner_port = miner_port
-        self.my_keypair = my_keypair
-
-        loop = asyncio.get_running_loop()
-        self.miner_manifest = loop.create_future()
-        self.online_executor_count = 0
-
-        # for waiting on miner responses (replaces JobState)
-        self.miner_ready_or_declining_future = loop.create_future()
-        self.miner_ready_or_declining_timestamp: int = 0
-        self.miner_finished_or_failed_future = loop.create_future()
-        self.miner_finished_or_failed_timestamp: int = 0
-        self.miner_machine_specs: MachineSpecs | None = None  # what should we do with this???
-
-        name = f"{miner_hotkey}({miner_address}:{miner_port})"
-        transport = transport or WSTransport(name, self.miner_url())
-        super().__init__(name, transport)
-
-    @cached_property
-    def my_hotkey(self) -> str:
-        return self.my_keypair.ss58_address
-
-    def miner_url(self) -> str:
-        return (
-            f"ws://{self.miner_address}:{self.miner_port}/v0.1/validator_interface/{self.my_hotkey}"
-        )
-
-    def accepted_request_type(self) -> type[BaseRequest]:
-        return BaseMinerRequest
-
-    def incoming_generic_error_class(self) -> type[BaseRequest]:
-        return miner_requests.GenericError
-
-    def outgoing_generic_error_class(self) -> type[BaseRequest]:
-        return validator_requests.GenericError
-
-    async def notify_generic_error(self, msg: BaseRequest):
-        # TODO: make empty
+class MinerClient(OrganicMinerClient):
+    async def notify_generic_error(self, msg: BaseRequest) -> None:
         msg = f"Received error message from miner {self.miner_name}: {msg.model_dump_json()}"
         await SystemEvent.objects.using(settings.DEFAULT_DB_ALIAS).acreate(
             type=SystemEvent.EventType.MINER_ORGANIC_JOB_FAILURE,
@@ -99,7 +21,6 @@ class MinerClient(AbstractMinerClient):
         )
 
     async def notify_unauthorized_error(self, msg: UnauthorizedError) -> None:
-        # TODO: make empty
         msg = f"Unauthorized in {self.miner_name}: {msg.code}, details: {msg.details}"
         await SystemEvent.objects.using(settings.DEFAULT_DB_ALIAS).acreate(
             type=SystemEvent.EventType.MINER_ORGANIC_JOB_FAILURE,
@@ -109,7 +30,6 @@ class MinerClient(AbstractMinerClient):
         )
 
     async def notify_receipt_failure(self, comment: str) -> None:
-        # TODO: make empty
         await SystemEvent.objects.using(settings.DEFAULT_DB_ALIAS).acreate(
             type=SystemEvent.EventType.RECEIPT_FAILURE,
             subtype=SystemEvent.EventSubType.RECEIPT_SEND_ERROR,
@@ -118,151 +38,9 @@ class MinerClient(AbstractMinerClient):
         )
 
     async def job_error_event_callback(self, msg: str) -> None:
-        # TODO: make empty
         await SystemEvent.objects.using(settings.DEFAULT_DB_ALIAS).acreate(
             type=SystemEvent.EventType.MINER_ORGANIC_JOB_FAILURE,
             subtype=SystemEvent.EventSubType.MINER_SEND_ERROR,
             long_description=msg,
             data={"job_uuid": self.job_uuid, "miner_hotkey": self.miner_hotkey},
         )
-
-    async def handle_manifest_request(self, msg: V0ExecutorManifestRequest) -> None:
-        try:
-            self.miner_manifest.set_result(msg.manifest)
-        except asyncio.InvalidStateError:
-            logger.warning(f"Received manifest from {msg} but future was already set")
-
-    async def handle_machine_specs_request(self, msg: V0MachineSpecsRequest) -> None:
-        self.miner_machine_specs = msg.specs
-
-    async def handle_message(self, msg: BaseRequest) -> None:
-        if isinstance(msg, self.incoming_generic_error_class()):
-            logger.warning(
-                f"Received error message from miner {self.miner_name}: {msg.model_dump_json()}"
-            )
-            await self.notify_generic_error(msg)
-            return
-        elif isinstance(msg, UnauthorizedError):
-            logger.error(f"Unauthorized in {self.miner_name}: {msg.code}, details: {msg.details}")
-            await self.notify_unauthorized_error(msg)
-            return
-        elif isinstance(msg, V0ExecutorManifestRequest):
-            await self.handle_manifest_request(msg)
-            return
-
-        if isinstance(msg, V0AcceptJobRequest):
-            logger.info(f"Miner {self.miner_name} accepted job")
-        elif isinstance(
-            msg, V0DeclineJobRequest | V0ExecutorFailedRequest | V0ExecutorReadyRequest
-        ):
-            try:
-                self.miner_ready_or_declining_future.set_result(msg)
-                self.miner_ready_or_declining_timestamp = time.time()
-            except asyncio.InvalidStateError:
-                logger.warning(f"Received {msg} from {self.miner_name} but future was already set")
-        elif isinstance(msg, V0JobFailedRequest | V0JobFinishedRequest):
-            try:
-                self.miner_finished_or_failed_future.set_result(msg)
-                self.miner_finished_or_failed_timestamp = time.time()
-            except asyncio.InvalidStateError:
-                logger.warning(f"Received {msg} from {self.miner_name} but future was already set")
-        elif isinstance(msg, V0MachineSpecsRequest):
-            await self.handle_machine_specs_request(msg)
-        else:
-            raise UnsupportedMessageReceived(msg)
-
-    def generate_authentication_message(self) -> V0AuthenticateRequest:
-        payload = AuthenticationPayload(
-            validator_hotkey=self.my_hotkey,
-            miner_hotkey=self.miner_hotkey,
-            timestamp=int(time.time()),
-        )
-        return V0AuthenticateRequest(
-            payload=payload, signature=f"0x{self.my_keypair.sign(payload.blob_for_signing()).hex()}"
-        )
-
-    def generate_job_started_receipt_message(
-        self,
-        executor_class: ExecutorClass,
-        accepted_timestamp: float,
-        max_timeout: int,
-    ) -> V0JobStartedReceiptRequest:
-        time_accepted = datetime.datetime.fromtimestamp(accepted_timestamp, datetime.UTC)
-        receipt_payload = JobStartedReceiptPayload(
-            job_uuid=self.job_uuid,
-            miner_hotkey=self.miner_hotkey,
-            validator_hotkey=self.my_hotkey,
-            executor_class=executor_class,
-            time_accepted=time_accepted,
-            max_timeout=max_timeout,
-        )
-        return V0JobStartedReceiptRequest(
-            payload=receipt_payload,
-            signature=f"0x{self.my_keypair.sign(receipt_payload.blob_for_signing()).hex()}",
-        )
-
-    async def send_job_started_receipt_message(
-        self,
-        executor_class: ExecutorClass,
-        accepted_timestamp: float,
-        max_timeout: int,
-    ) -> None:
-        try:
-            receipt_message = self.generate_job_started_receipt_message(
-                executor_class,
-                accepted_timestamp,
-                max_timeout,
-            )
-            await self.send_model(
-                receipt_message,
-                error_event_callback=self.job_error_event_callback,
-            )
-            logger.debug(f"Sent job started receipt for {self.job_uuid}")
-        except Exception as e:
-            comment = f"Failed to send job started receipt to miner {self.miner_name} for job {self.job_uuid}: {e}"
-            logger.warning(comment)
-            await self.notify_receipt_failure(comment)
-
-    def generate_job_finished_receipt_message(
-        self,
-        started_timestamp: float,
-        time_took_seconds: float,
-        score: float,
-    ) -> V0JobFinishedReceiptRequest:
-        time_started = datetime.datetime.fromtimestamp(started_timestamp, datetime.UTC)
-        receipt_payload = JobFinishedReceiptPayload(
-            job_uuid=self.job_uuid,
-            miner_hotkey=self.miner_hotkey,
-            validator_hotkey=self.my_hotkey,
-            time_started=time_started,
-            time_took_us=int(time_took_seconds * 1_000_000),
-            score_str=f"{score:.6f}",
-        )
-        return V0JobFinishedReceiptRequest(
-            payload=receipt_payload,
-            signature=f"0x{self.my_keypair.sign(receipt_payload.blob_for_signing()).hex()}",
-        )
-
-    async def send_job_finished_receipt_message(
-        self,
-        started_timestamp: float,
-        time_took_seconds: float,
-        score: float,
-    ) -> None:
-        try:
-            receipt_message = self.generate_job_finished_receipt_message(
-                started_timestamp, time_took_seconds, score
-            )
-            await self.send_model(
-                receipt_message,
-                error_event_callback=self.job_error_event_callback,
-            )
-            logger.debug(f"Sent job finished receipt for {self.job_uuid}")
-        except Exception as e:
-            comment = f"Failed to send job finished receipt to miner {self.miner_name} for job {self.job_uuid}: {e}"
-            logger.warning(comment)
-            await self.notify_receipt_failure(comment)
-
-    async def connect(self) -> None:
-        await super().connect()
-        await self.transport.send(self.generate_authentication_message().model_dump_json())

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_client.py
@@ -37,7 +37,7 @@ class MinerClient(OrganicMinerClient):
             data={"job_uuid": self.job_uuid, "miner_hotkey": self.miner_hotkey},
         )
 
-    async def job_error_event_callback(self, msg: str) -> None:
+    async def notify_send_failure(self, msg: str) -> None:
         await SystemEvent.objects.using(settings.DEFAULT_DB_ALIAS).acreate(
             type=SystemEvent.EventType.MINER_ORGANIC_JOB_FAILURE,
             subtype=SystemEvent.EventSubType.MINER_SEND_ERROR,

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
@@ -17,6 +17,7 @@ from compute_horde.mv_protocol.miner_requests import (
     V0JobFinishedRequest,
 )
 from compute_horde.mv_protocol.validator_requests import V0InitialJobRequest, V0JobRequest
+from compute_horde.utils import Timer
 from django.conf import settings
 from pydantic import BaseModel
 
@@ -27,7 +28,7 @@ from compute_horde_validator.validator.models import (
     SystemEvent,
 )
 from compute_horde_validator.validator.organic_jobs.facilitator_api import V0FacilitatorJobRequest
-from compute_horde_validator.validator.utils import Timer, get_dummy_inline_zip_volume
+from compute_horde_validator.validator.utils import get_dummy_inline_zip_volume
 
 logger = logging.getLogger(__name__)
 

--- a/validator/app/src/compute_horde_validator/validator/tests/test_utils.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_utils.py
@@ -2,20 +2,17 @@ import asyncio
 import logging
 import threading
 import time
-import uuid
 from unittest.mock import MagicMock, patch
 
 import bittensor
 import pytest
 from asgiref.sync import sync_to_async
-from compute_horde.base_requests import BaseRequest
 from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS, ExecutorClass
 from compute_horde.mv_protocol.miner_requests import (
     ExecutorClassManifest,
     ExecutorManifest,
     V0AcceptJobRequest,
     V0DeclineJobRequest,
-    V0ExecutorFailedRequest,
     V0ExecutorManifestRequest,
     V0ExecutorReadyRequest,
     V0JobFailedRequest,
@@ -33,7 +30,6 @@ from compute_horde_validator.validator.models import (
     SyntheticJobBatch,
     SystemEvent,
 )
-from compute_horde_validator.validator.organic_jobs.miner_client import MinerClient
 from compute_horde_validator.validator.synthetic_jobs.batch_run import (
     execute_synthetic_batch_run,
 )
@@ -47,7 +43,6 @@ from compute_horde_validator.validator.synthetic_jobs.utils import (
 
 from .helpers import (
     check_system_events,
-    get_miner_client,
 )
 
 MOCK_SCORE = 0.8
@@ -356,50 +351,6 @@ async def test_execute_synthetic_job(
         await sync_to_async(check_system_events)(*expected_system_event)
     else:
         assert await SystemEvent.objects.aget() == 0
-
-
-# TODO: move to organic job tests
-@pytest.mark.asyncio
-@pytest.mark.django_db(databases=["default", "default_alias"], transaction=True)
-@pytest.mark.parametrize(
-    "msg",
-    [
-        V0ExecutorReadyRequest(job_uuid=str(uuid.uuid4())),
-        V0ExecutorFailedRequest(job_uuid=str(uuid.uuid4())),
-        V0ExecutorReadyRequest(job_uuid=str(uuid.uuid4())),
-    ],
-)
-async def test_miner_client__handle_message__set_ready_or_declining_future(msg: BaseRequest):
-    miner_client = get_miner_client(MinerClient, msg.job_uuid)
-    assert not miner_client.miner_ready_or_declining_future.done()
-    await miner_client.handle_message(msg)
-    assert await miner_client.miner_ready_or_declining_future == msg
-
-
-# TODO: move to organic job tests
-@pytest.mark.asyncio
-@pytest.mark.django_db(databases=["default", "default_alias"], transaction=True)
-@pytest.mark.parametrize(
-    "msg",
-    [
-        V0JobFailedRequest(
-            job_uuid=str(uuid.uuid4()),
-            docker_process_exit_status=1,
-            docker_process_stdout="stdout",
-            docker_process_stderr="stderr",
-        ),
-        V0JobFinishedRequest(
-            job_uuid=str(uuid.uuid4()),
-            docker_process_stdout="stdout",
-            docker_process_stderr="stderr",
-        ),
-    ],
-)
-async def test_miner_client__handle_message__set_other_msg(msg: BaseRequest):
-    miner_client = get_miner_client(MinerClient, msg.job_uuid)
-    assert not miner_client.miner_finished_or_failed_future.done()
-    await miner_client.handle_message(msg)
-    assert await miner_client.miner_finished_or_failed_future == msg
 
 
 async def create_mock_job_batches(miner):

--- a/validator/app/src/compute_horde_validator/validator/utils.py
+++ b/validator/app/src/compute_horde_validator/validator/utils.py
@@ -1,5 +1,4 @@
 import base64
-import datetime as dt
 import io
 import zipfile
 from functools import cache
@@ -15,20 +14,6 @@ def single_file_zip(filename: str, contents: str) -> str:
     in_memory_output.seek(0)
     zip_contents = in_memory_output.read()
     return base64.b64encode(zip_contents).decode()
-
-
-class Timer:
-    def __init__(self, timeout=None):
-        self.start_time = dt.datetime.now()
-        self.timeout = timeout
-
-    def passed_time(self):
-        return (dt.datetime.now() - self.start_time).total_seconds()
-
-    def time_left(self):
-        if self.timeout is None:
-            raise ValueError("timeout was not specified")
-        return self.timeout - self.passed_time()
 
 
 @cache


### PR DESCRIPTION
- Move miner client for running organic jobs from validator to the library, removing django specific things.
- Add django specific things (system event models etc.) in the subclass in validator.