### PR TITLE
Raise original exception when using save_event_on_error

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/tasks.py
+++ b/validator/app/src/compute_horde_validator/validator/tasks.py
@@ -613,6 +613,7 @@ def save_event_on_error(subtype):
         yield
     except Exception:
         save_weight_setting_failure(subtype, traceback.format_exc(), {})
+        raise
 
 
 def get_subtensor(network):


### PR DESCRIPTION
When not using `raise` statement, the code
```python
@contextlib.contextmanager
def save_event_on_error(subtype):
    try:
        yield
    except Exception:
        save_weight_setting_failure(subtype, traceback.format_exc(), {})
```
will suppress the error and return `None`, which will lead to weird errors like https://sentry.reef.pl/organizations/reef-technologies/issues/730505/?project=61&referrer=slack, where `get_subtensor()` returns `None`.