### PR TITLE
Fix BaseExecutorManager.get_executor_class_pool

### DIFF
--- a/miner/app/src/compute_horde_miner/miner/executor_manager/_internal/base.py
+++ b/miner/app/src/compute_horde_miner/miner/executor_manager/_internal/base.py
@@ -119,7 +119,7 @@ class BaseExecutorManager(metaclass=abc.ABCMeta):
         Keys are executor class ids and values are number of supported executors for given executor class.
         """
 
-    async def get_executor_class_pool(self, executor_class):
+    async def _sync_pools_with_manifest(self):
         manifest = await self.get_manifest()
         for executor_class, executor_count in manifest.items():
             pool = self._executor_class_pools.get(executor_class)
@@ -128,6 +128,9 @@ class BaseExecutorManager(metaclass=abc.ABCMeta):
                 self._executor_class_pools[executor_class] = pool
             else:
                 pool.set_count(executor_count)
+
+    async def get_executor_class_pool(self, executor_class):
+        await self._sync_pools_with_manifest()
         return self._executor_class_pools[executor_class]
 
     async def reserve_executor_class(self, token, executor_class, timeout):


### PR DESCRIPTION
It was returning the same pool regardless of the passed in `executor_class`. The `executor_class` was being overridden inside in the for loop for using the same variable name.