### PR TITLE
Use transaction specific advisory lock

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/locks.py
+++ b/validator/app/src/compute_horde_validator/validator/locks.py
@@ -18,7 +18,7 @@ def get_advisory_lock(type_: LockType) -> None:
     will be released automatically after transaction.atomic ends.
     """
     cursor = connection.cursor()
-    cursor.execute("SELECT pg_try_advisory_lock(%s)", [type_])
+    cursor.execute("SELECT pg_try_advisory_xact_lock(%s)", [type_])
     unlocked = cursor.fetchall()[0][0]
     if not unlocked:
         raise Locked


### PR DESCRIPTION
The `get_advisory_lock` function documentation says that the function must be called within an atomic block and the lock will be released automatically after the atomic block ends. But that is not the case.

The advisory lock used here (`pg_try_advisory_lock`) is a session-level lock. It does not require an atomic block. To unlock, either `pg_advisory_unlock` needs to be explicitly called or the session needs to end.

This PR uses `pg_try_advisory_xact_lock` to create transaction level lock. It works as the function documentation.