### PR TITLE
Properly handle miner responses in organic client

### DIFF
--- a/compute_horde/tests/test_run_organic_job.py
+++ b/compute_horde/tests/test_run_organic_job.py
@@ -5,7 +5,11 @@ from compute_horde.miner_client.organic import (
     OrganicMinerClient,
     run_organic_job,
 )
-from compute_horde.mv_protocol.miner_requests import V0ExecutorReadyRequest, V0JobFinishedRequest
+from compute_horde.mv_protocol.miner_requests import (
+    V0AcceptJobRequest,
+    V0ExecutorReadyRequest,
+    V0JobFinishedRequest,
+)
 from compute_horde.mv_protocol.validator_requests import (
     BaseValidatorRequest,
     V0AuthenticateRequest,
@@ -34,6 +38,7 @@ async def test_run_organic_job__success(keypair):
     mock_transport = MinerStubTransport(
         "mock",
         [
+            V0AcceptJobRequest(job_uuid=JOB_UUID).model_dump_json(),
             V0ExecutorReadyRequest(job_uuid=JOB_UUID).model_dump_json(),
             V0JobFinishedRequest(
                 job_uuid=JOB_UUID,

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
@@ -9,6 +9,7 @@ from compute_horde.base.output_upload import ZipAndHttpPutUpload
 from compute_horde.base.volume import InlineVolume, Volume, ZipUrlVolume
 from compute_horde.executor_class import ExecutorClass
 from compute_horde.mv_protocol.miner_requests import (
+    V0AcceptJobRequest,
     V0DeclineJobRequest,
     V0ExecutorFailedRequest,
     V0ExecutorReadyRequest,
@@ -147,7 +148,7 @@ async def execute_organic_job(
 
         try:
             msg = await asyncio.wait_for(
-                miner_client.miner_ready_or_declining_future,
+                miner_client.miner_accepting_or_declining_future,
                 timeout=min(job_timer.time_left(), wait_timeout),
             )
         except TimeoutError:
@@ -165,7 +166,7 @@ async def execute_organic_job(
                 await notify_callback(JobStatusUpdate.from_job(job, "failed"))
             return
 
-        if isinstance(msg, V0DeclineJobRequest | V0ExecutorFailedRequest):
+        if isinstance(msg, V0DeclineJobRequest):
             comment = f"Miner {miner_client.miner_name} won't do job: {msg.model_dump_json()}"
             job.status = OrganicJob.Status.FAILED
             job.comment = comment
@@ -178,6 +179,47 @@ async def execute_organic_job(
             )
             if notify_callback:
                 await notify_callback(JobStatusUpdate.from_job(job, "rejected"))
+            return
+        elif isinstance(msg, V0AcceptJobRequest):
+            logger.debug(f"Miner {miner_client.miner_name} accepted job: {msg}")
+        else:
+            raise ValueError(f"Unexpected msg from miner {miner_client.miner_name}: {msg}")
+
+        try:
+            msg = await asyncio.wait_for(
+                miner_client.executor_ready_or_failed_future,
+                timeout=min(job_timer.time_left(), wait_timeout),
+            )
+        except TimeoutError:
+            comment = f"Miner {miner_client.miner_name} timed out while preparing executor for job {job.job_uuid} after {wait_timeout} seconds"
+            job.status = OrganicJob.Status.FAILED
+            job.comment = comment
+            await job.asave()
+
+            logger.warning(comment)
+            await save_event(
+                subtype=SystemEvent.EventSubType.JOB_NOT_STARTED,
+                long_description=comment,
+            )
+            if notify_callback:
+                await notify_callback(JobStatusUpdate.from_job(job, "failed"))
+            return
+
+        if isinstance(msg, V0ExecutorFailedRequest):
+            comment = (
+                f"Miner {miner_client.miner_name} failed to start executor: {msg.model_dump_json()}"
+            )
+            job.status = OrganicJob.Status.FAILED
+            job.comment = comment
+            await job.asave()
+
+            logger.info(comment)
+            await save_event(
+                subtype=SystemEvent.EventSubType.JOB_REJECTED,
+                long_description=comment,
+            )
+            if notify_callback:
+                await notify_callback(JobStatusUpdate.from_job(job, "failed"))
             return
         elif isinstance(msg, V0ExecutorReadyRequest):
             logger.debug(f"Miner {miner_client.miner_name} ready for job: {msg}")

--- a/validator/app/src/compute_horde_validator/validator/tests/helpers.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/helpers.py
@@ -15,6 +15,7 @@ import numpy as np
 from bittensor import Balance
 from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS
 from compute_horde.mv_protocol.miner_requests import (
+    V0AcceptJobRequest,
     V0ExecutorReadyRequest,
     V0JobFinishedRequest,
 )
@@ -119,7 +120,10 @@ class MockMinerClient(MinerClient):
 class MockJobStateMinerClient(MockMinerClient):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.miner_ready_or_declining_future.set_result(
+        self.miner_accepting_or_declining_future.set_result(
+            V0AcceptJobRequest(job_uuid=self.job_uuid)
+        )
+        self.executor_ready_or_failed_future.set_result(
             V0ExecutorReadyRequest(job_uuid=self.job_uuid)
         )
         self.miner_finished_or_failed_future.set_result(

--- a/validator/app/src/compute_horde_validator/validator/tests/test_miner_driver.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/test_miner_driver.py
@@ -3,7 +3,9 @@ import uuid
 import pytest
 from compute_horde.executor_class import DEFAULT_EXECUTOR_CLASS
 from compute_horde.mv_protocol.miner_requests import (
+    V0AcceptJobRequest,
     V0DeclineJobRequest,
+    V0ExecutorFailedRequest,
     V0ExecutorReadyRequest,
     V0JobFailedRequest,
     V0JobFinishedRequest,
@@ -40,7 +42,7 @@ WEBSOCKET_TIMEOUT = 10
     ),
     [
         (
-            (None, None),
+            (None, None, None),
             ["failed"],
             OrganicJob.Status.FAILED,
             get_dummy_job_request_v0,
@@ -48,7 +50,7 @@ WEBSOCKET_TIMEOUT = 10
             False,
         ),
         (
-            (V0DeclineJobRequest, None),
+            (V0DeclineJobRequest, None, None),
             ["rejected"],
             OrganicJob.Status.FAILED,
             get_dummy_job_request_v0,
@@ -56,7 +58,15 @@ WEBSOCKET_TIMEOUT = 10
             False,
         ),
         (
-            (V0ExecutorReadyRequest, None),
+            (V0AcceptJobRequest, V0ExecutorFailedRequest, None),
+            ["failed"],
+            OrganicJob.Status.FAILED,
+            get_dummy_job_request_v0,
+            False,
+            False,
+        ),
+        (
+            (V0AcceptJobRequest, V0ExecutorReadyRequest, None),
             ["accepted", "failed"],
             OrganicJob.Status.FAILED,
             get_dummy_job_request_v0,
@@ -64,7 +74,7 @@ WEBSOCKET_TIMEOUT = 10
             False,
         ),
         (
-            (V0ExecutorReadyRequest, V0JobFailedRequest),
+            (V0AcceptJobRequest, V0ExecutorReadyRequest, V0JobFailedRequest),
             ["accepted", "failed"],
             OrganicJob.Status.FAILED,
             get_dummy_job_request_v0,
@@ -72,7 +82,7 @@ WEBSOCKET_TIMEOUT = 10
             False,
         ),
         (
-            (V0ExecutorReadyRequest, V0JobFinishedRequest),
+            (V0AcceptJobRequest, V0ExecutorReadyRequest, V0JobFinishedRequest),
             ["accepted", "completed"],
             OrganicJob.Status.COMPLETED,
             get_dummy_job_request_v0,
@@ -80,7 +90,7 @@ WEBSOCKET_TIMEOUT = 10
             True,
         ),
         (
-            (V0ExecutorReadyRequest, V0JobFinishedRequest),
+            (V0AcceptJobRequest, V0ExecutorReadyRequest, V0JobFinishedRequest),
             ["accepted", "completed"],
             OrganicJob.Status.COMPLETED,
             get_dummy_job_request_v1,
@@ -111,12 +121,14 @@ async def test_miner_driver(
         job_description="User job from facilitator",
     )
     miner_client = get_miner_client(MockMinerClient, job_uuid)
-    f0, f1 = futures_result
+    f0, f1, f2 = futures_result
     if f0:
-        miner_client.miner_ready_or_declining_future.set_result(f0(job_uuid=job_uuid))
+        miner_client.miner_accepting_or_declining_future.set_result(f0(job_uuid=job_uuid))
     if f1:
+        miner_client.executor_ready_or_failed_future.set_result(f1(job_uuid=job_uuid))
+    if f2:
         miner_client.miner_finished_or_failed_future.set_result(
-            f1(
+            f2(
                 job_uuid=job_uuid,
                 docker_process_stdout="mocked stdout",
                 docker_process_stderr="mocked stderr",


### PR DESCRIPTION
The organic client does not properly handle the job accept/reject message before checking for executor ready/failed message.