### PR TITLE
Mark validator celery containers for auto update

### DIFF
--- a/validator/envs/runner/data/docker-compose.yml
+++ b/validator/envs/runner/data/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       - redis
     logging:
       <<: *logging
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
 
   celery-worker-weights:
     <<: *celery-worker


### PR DESCRIPTION
The label was removed by mistake in a receipt change.