### PR TITLE
A6000 README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for miner in miners:
 
 ## Validator
 
-To run a validator, first you need to [setup a trusted miner for cross-validation](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) and [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) of LLM jobs.
+To run a validator, first you need to [setup a trusted miner for cross-validation](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) and [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) of LLM jobs. Your trusted miner needs to have A6000 GPU, and be configured to use it. The validator doesn't need A6000. 
 
 **If you are upgrading** your validator to support LLM jobs, prepare a trusted miner and S3 buckets (find out how using the links above). Then, set the environment variables directly in the .env file of your validator instance and restart your validator:
 
@@ -77,10 +77,13 @@ export S3_BUCKET_NAME_ANSWERS=...
 
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
-export AWS_ENDPOINT_URL=...
+export AWS_DEFAULT_REGION=...
 ```
 
-Note: setting `AWS_ENDPOINT_URL` is optional. If not given, the default AWS S3 endpoint will be used.
+Note: `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are not in your default AWS region.
+
+Export `AWS_ENDPOINT_URL` too if you want to us another S3 provider. If not given, the default AWS S3 endpoint will be used.
+
 
 Then execute the following command from the same terminal session:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export AWS_DEFAULT_REGION=...
 
 Note: `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are not in your default AWS region.
 
-Export `AWS_ENDPOINT_URL` too if you want to us another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
+Export `AWS_ENDPOINT_URL` too if you want to use another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
 
 
 Then execute the following command from the same terminal session:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export AWS_DEFAULT_REGION=...
 
 Note: `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are not in your default AWS region.
 
-Export `AWS_ENDPOINT_URL` too if you want to us another S3 provider. If not given, the default AWS S3 endpoint will be used.
+Export `AWS_ENDPOINT_URL` too if you want to us another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
 
 
 Then execute the following command from the same terminal session:

--- a/validator/README.md
+++ b/validator/README.md
@@ -89,7 +89,7 @@ curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/val
 
 Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets you want to use for prompts and answers respectively. It will automatically create a dedicated user, assign permissions policy for created buckets, and add an access key, displaying it at the end so it can be copied to the validator env file. If you don't want to create a user and prefer to handle permissions manually, just skip the `--create-user` option.
 
-Note: if your buckets are not in your default AWS region export `AWS_DEFAULT_REGION` before running the script (both buckets needs to be in the same region):
+Note: if your buckets are not in your default AWS region export `AWS_DEFAULT_REGION` before running the script (both buckets needs to be in the same region), and add it to `.env` later:
 ```
 export AWS_DEFAULT_REGION=BUCKETS_REGION
 ```

--- a/validator/README.md
+++ b/validator/README.md
@@ -89,6 +89,11 @@ curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/val
 
 Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets you want to use for prompts and answers respectively. It will automatically create a dedicated user, assign permissions policy for created buckets, and add an access key, displaying it at the end so it can be copied to the validator env file. If you don't want to create a user and prefer to handle permissions manually, just skip the `--create-user` option.
 
+Note: if your buckets are not in your default AWS region export `AWS_DEFAULT_REGION` before running the script (both buckets needs to be in the same region):
+```
+export AWS_DEFAULT_REGION=BUCKETS_REGION
+```
+
 At the end of the script, it will show the values for `S3_BUCKET_NAME_PROMPTS`, `S3_BUCKET_NAME_ANSWERS`.
 If you used `--create-user` flag, it will also show the values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 You have to copy these variables in your validator `.env` file and restart your validator.
@@ -97,12 +102,20 @@ You have to copy these variables in your validator `.env` file and restart your 
 > If you did not use `--create-user`, you still need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your validator .env file.
 > In that case, you will have to manually generate the credentials.
 
+> [!NOTE]
+> We have tested the AWS S3. The buckets are used to allow quick and concurrent upload and download of multiple (but tiny) text files.
+
 ### Updated validator .env
 
 Add or update these variables in the validator `.env` file:
 
 ```
-TRUSTED_MINER_KEY = "HOTKEY"
 TRUSTED_MINER_ADDRESS = "MINER_IP"
 TRUSTED_MINER_PORT = MINER_PORT
+```
+
+If your buckets are not in the default AWS region, add also:
+
+```
+AWS_DEFAULT_REGION = BUCKETS_REGION
 ```


### PR DESCRIPTION
In this PR:
- [x] describing `AWS_DEFAULT_REGION` variable
- [x] mention about A6000 being needed, and that the buckets needs to handle small text files