### PR TITLE
Readme changes after a validator installation call

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export AWS_DEFAULT_REGION=...
 
 Note: The `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are not in your default AWS region.
 
-Export `AWS_ENDPOINT_URL` if you want to use another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
+Export `AWS_ENDPOINT_URL` to use another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
 
 Then execute the following command from the same terminal session:
 
@@ -109,7 +109,7 @@ Replace:
 - `SSH_DESTINATION` with your server's connection info (i.e. `username@1.2.3.4`)
 - `HOTKEY_PATH` with the path of your hotkey (i.e. `~/.bittensor/wallets/my-wallet/hotkeys/my-hotkey`)
 
-This script installs the necessary tools in the server, copies the public keys and starts the validator with the corresponding runner and the default config.
+This script installs the necessary tools in the server, copies the public keys,  and starts the validator with the corresponding runner and the default config.
 
 If you want to change the default config, see [Validator runner README](validator/envs/runner/README.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ ComputeHorde validator is built out of three components
 1. validator machine (standard, non-GPU) - for regular validating & weight-setting
 
 The steps (performed by running installation scripts **on your local machine** (the machine where you have your wallet files)):
-1. [setup trusted miner](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) 
-1. [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) 
+1. [setup trusted miner](/validator#setting-up-a-trusted-miner-for-cross-validation) 
+1. [provision S3 buckets for prompts and answers](/validator#provision-s3-buckets-for-prompts-and-answers) 
 1. [setup validator](#validator-setup)
 
 ### Validator setup

--- a/README.md
+++ b/README.md
@@ -58,7 +58,17 @@ for miner in miners:
 
 ## Validator
 
-To run a validator, first you need to [setup a trusted miner for cross-validation](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) and [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) of LLM jobs. Your trusted miner needs to have A6000 GPU, and be configured to use it. The validator doesn't need A6000. 
+ComputeHorde validator is built out of three components
+1. trusted miner (requires A6000 (the only GPU supported now)) for cross-validation
+1. two s3 buckets for sharing LLM data (lots of small text files)
+1. validator machine (standard, non-GPU) - for regular validating & weight-setting
+
+The steps:
+1. [setup trusted miner](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) 
+1. [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) 
+1. [setup validator](#validator-setup)
+
+### Validator Setup
 
 **If you are upgrading** your validator to support LLM jobs, prepare a trusted miner and S3 buckets (find out how using the links above). Then, set the environment variables directly in the .env file of your validator instance and restart your validator:
 

--- a/README.md
+++ b/README.md
@@ -60,23 +60,28 @@ for miner in miners:
 
 ComputeHorde validator is built out of three components
 1. trusted miner (requires A6000 (the only GPU supported now)) for cross-validation
-1. two s3 buckets for sharing LLM data (lots of small text files)
+1. two S3 buckets for sharing LLM data (lots of small text files)
 1. validator machine (standard, non-GPU) - for regular validating & weight-setting
 
-The steps:
+The steps (performed by running installation scripts **on your local maching** (the machine where you have your wallet files)):
 1. [setup trusted miner](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) 
 1. [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) 
 1. [setup validator](#validator-setup)
 
-### Validator Setup
+### Validator setup
 
-**If you are upgrading** your validator to support LLM jobs, prepare a trusted miner and S3 buckets (find out how using the links above). Then, set the environment variables directly in the .env file of your validator instance and restart your validator:
+#### Upgrading already existing deployment
+
+Prepare a trusted miner and S3 buckets (find out how using the links above). 
+Then, set the [environment variables](#deploying-from-scratch) directly in the `.env` file of your **validator** instance and restart your validator:
 
 ```
 $ docker compose down --remove-orphans && docker compose up -d
 ```
 
-Set the following environment variables in a terminal on your local machine (on the machine where you have your wallet files):
+#### Deploying from scratch
+
+Set the following environment variables in a terminal on your **local machine** (on the machine where you have your wallet files):
 
 ```sh
 export TRUSTED_MINER_ADDRESS=...
@@ -94,16 +99,17 @@ Note: `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are no
 
 Export `AWS_ENDPOINT_URL` too if you want to use another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
 
-
 Then execute the following command from the same terminal session:
 
 ```shell
 curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/install_validator.sh | bash -s - SSH_DESTINATION HOTKEY_PATH
 ```
 
-Replace `SSH_DESTINATION` with your server's connection info (i.e. `username@1.2.3.4`)
-and `HOTKEY_PATH` with the path of your hotkey (i.e. `~/.bittensor/wallets/my-wallet/hotkeys/my-hotkey`).
-This script installs necessary tools in the server, copies the keys and starts the validator with the corresponding runner and default config.
+Replace:
+- `SSH_DESTINATION` with your server's connection info (i.e. `username@1.2.3.4`)
+- `HOTKEY_PATH` with the path of your hotkey (i.e. `~/.bittensor/wallets/my-wallet/hotkeys/my-hotkey`)
+
+This script installs necessary tools in the server, copies the public keys and starts the validator with the corresponding runner and the default config.
 
 If you want to change the default config, see [Validator runner README](validator/envs/runner/README.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ComputeHorde validator is built out of three components
 1. two S3 buckets for sharing LLM data (lots of small text files)
 1. validator machine (standard, non-GPU) - for regular validating & weight-setting
 
-The steps (performed by running installation scripts **on your local maching** (the machine where you have your wallet files)):
+The steps (performed by running installation scripts **on your local machine** (the machine where you have your wallet files)):
 1. [setup trusted miner](/validator/README.md#setting-up-a-trusted-miner-for-cross-validation) 
 1. [provision S3 buckets for prompts and answers](/validator/README.md#provision-s3-buckets-for-prompts-and-answers) 
 1. [setup validator](#validator-setup)
@@ -95,9 +95,9 @@ export AWS_SECRET_ACCESS_KEY=...
 export AWS_DEFAULT_REGION=...
 ```
 
-Note: `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are not in your default AWS region.
+Note: The `AWS_DEFAULT_REGION` property is optional. Use it when your buckets are not in your default AWS region.
 
-Export `AWS_ENDPOINT_URL` too if you want to use another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
+Export `AWS_ENDPOINT_URL` if you want to use another cloud object storage (s3-compatible) provider. If not given, AWS S3 will be used.
 
 Then execute the following command from the same terminal session:
 
@@ -109,7 +109,7 @@ Replace:
 - `SSH_DESTINATION` with your server's connection info (i.e. `username@1.2.3.4`)
 - `HOTKEY_PATH` with the path of your hotkey (i.e. `~/.bittensor/wallets/my-wallet/hotkeys/my-hotkey`)
 
-This script installs necessary tools in the server, copies the public keys and starts the validator with the corresponding runner and the default config.
+This script installs the necessary tools in the server, copies the public keys and starts the validator with the corresponding runner and the default config.
 
 If you want to change the default config, see [Validator runner README](validator/envs/runner/README.md) for details.
 
@@ -125,7 +125,7 @@ curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/ins
 
 Replace `SSH_DESTINATION` with your server's connection info (i.e. `username@1.2.3.4`)
 and `HOTKEY_PATH` with the path of your hotkey (i.e. `~/.bittensor/wallets/my-wallet/hotkeys/my-hotkey`).
-This script installs necessary tools in the server, copies the keys and starts the miner with the corresponding runner and default config.
+This script installs necessary tools in the server, copies the keys, and starts the miner with the corresponding runner and default config.
 
 If you want to change the default config, see [Miner runner README](miner/envs/runner/README.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ for miner in miners:
 ## Validator
 
 ComputeHorde validator is built out of three components
-1. trusted miner (requires A6000 (the only GPU supported now)) for cross-validation
+1. trusted miner (requires A6000 - the only GPU supported now) for cross-validation
 1. two S3 buckets for sharing LLM data (lots of small text files)
 1. validator machine (standard, non-GPU) - for regular validating & weight-setting
 
-The steps (performed by running installation scripts **on your local machine** (the machine where you have your wallet files)):
+The steps, performed by running installation scripts **on your local machine**, which has your wallet files. For clarity, **these installation scripts are not run on the machine that will become the trusted miner or the validator**, the scripts will connect through SSH to those machines from your local machine:
 1. [setup trusted miner](/validator#setting-up-a-trusted-miner-for-cross-validation) 
 1. [provision S3 buckets for prompts and answers](/validator#provision-s3-buckets-for-prompts-and-answers) 
 1. [setup validator](#validator-setup)

--- a/validator/README.md
+++ b/validator/README.md
@@ -76,7 +76,7 @@ Replace the placeholders in the command above:
 - `SSH_DESTINATION`: your server's connection info (i.e. `username@1.2.3.4`)
 - `VALIDATOR_PUBLIC_KEY`: the public key of your validator (_not_ the path to the key)
 - `MINER_PORT` (optional): the port (of your choosing) on which the miner will listen for incoming connections (default is 8000)
-- `DEFAULT_EXECUTOR_CLASS` (optional): specify a custom executor class to use; set **`always_on.llm.a6000` is mandatory to support A6000 synthetic job flow** 
+- `DEFAULT_EXECUTOR_CLASS` (optional): specifies a custom executor class to use. **For A6000 synthetic job support, `always_on.llm.a6000` must be set**
 
 ## Provision S3 buckets for prompts and answers
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -74,20 +74,25 @@ curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/ins
 
 Replace the placeholders in the command above:
 - `SSH_DESTINATION`: your server's connection info (i.e. `username@1.2.3.4`)
-- `VALIDATOR_PUBLIC_KEY`: the public key of your validator (not a path to the key)
-- `MINER_PORT` (optional): the port on which the miner will listen for incoming connections (default is 8000)
-- `DEFAULT_EXECUTOR_CLASS` (optional): specify a custom executor class to use; **to support A6000 synthetic job flow, setting `always_on.llm.a6000` is mandatory** 
+- `VALIDATOR_PUBLIC_KEY`: the public key of your validator (_not_ the path to the key)
+- `MINER_PORT` (optional): the port (of your choosing) on which the miner will listen for incoming connections (default is 8000)
+- `DEFAULT_EXECUTOR_CLASS` (optional): specify a custom executor class to use; set **`always_on.llm.a6000` is mandatory to support A6000 synthetic job flow** 
 
 ### Provision S3 buckets for prompts and answers
 
-Trusted miners require S3 buckets to store prompts and answers. To provision these buckets conveniently with the correct permissions pre-configured, make sure you have [AWS CLI](https://aws.amazon.com/cli/) installed and configured.
+Trusted miners require S3 buckets to store prompts and answers. 
+
+**Make sure** you have [AWS CLI](https://aws.amazon.com/cli/) installed and configured, 
+to provision these buckets conveniently with the correct permissions pre-configured. 
+
 Then run the following script:
 
 ```sh
 curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/validator/provision_s3.sh | bash -s - PROMPTS_BUCKET ANSWERS_BUCKET --create-user
 ```
 
-Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets you want to use for prompts and answers respectively. 
+Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets you want to use for prompts and answers respectively.
+
 It will automatically create a dedicated user, assign permissions policy for created buckets, and add an access key, 
 displaying it at the end so it can be copied to the validator `.env` file. 
 
@@ -114,8 +119,8 @@ You have to copy these variables in your validator `.env` file and restart your 
 Add or update these variables in the validator `.env` file:
 
 ```
-TRUSTED_MINER_ADDRESS = "MINER_IP"
-TRUSTED_MINER_PORT = MINER_PORT
+TRUSTED_MINER_ADDRESS="MINER_IP"
+TRUSTED_MINER_PORT=MINER_PORT
 ```
 
 If your buckets are not in the default AWS region, add also:

--- a/validator/README.md
+++ b/validator/README.md
@@ -108,7 +108,7 @@ If you use the `--create-user` flag, it will also show the values for `AWS_ACCES
 opy these variables in your validator `.env` file and restart your validator.
 
 > [!WARNING]  
-> If you did not use `--create-user`, you still need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your validator `.env` file.
+> Even if you did not use `--create-user`, you still need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your validator `.env` file.
 > In that case, you will have to manually generate the credentials.
 
 > [!NOTE]

--- a/validator/README.md
+++ b/validator/README.md
@@ -73,10 +73,10 @@ curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/ins
 ```
 
 Replace the placeholders in the command above:
-- SSH_DESTINATION: your server's connection info (i.e. `username@1.2.3.4`)
-- VALIDATOR_PUBLIC_KEY: the public key of your validator
-- MINER_PORT (optional): the port on which the miner will listen for incoming connections (default is 8000)
-- DEFAULT_EXECUTOR_CLASS (optional): specify a custom executor class to use; **to support A6000 synthetic job flow, setting `always_on.llm.a6000` is mandatory** 
+- `SSH_DESTINATION`: your server's connection info (i.e. `username@1.2.3.4`)
+- `VALIDATOR_PUBLIC_KEY`: the public key of your validator (not a path to the key)
+- `MINER_PORT` (optional): the port on which the miner will listen for incoming connections (default is 8000)
+- `DEFAULT_EXECUTOR_CLASS` (optional): specify a custom executor class to use; **to support A6000 synthetic job flow, setting `always_on.llm.a6000` is mandatory** 
 
 ### Provision S3 buckets for prompts and answers
 
@@ -87,7 +87,11 @@ Then run the following script:
 curl -sSfL https://github.com/backend-developers-ltd/ComputeHorde/raw/master/validator/provision_s3.sh | bash -s - PROMPTS_BUCKET ANSWERS_BUCKET --create-user
 ```
 
-Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets you want to use for prompts and answers respectively. It will automatically create a dedicated user, assign permissions policy for created buckets, and add an access key, displaying it at the end so it can be copied to the validator env file. If you don't want to create a user and prefer to handle permissions manually, just skip the `--create-user` option.
+Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets you want to use for prompts and answers respectively. 
+It will automatically create a dedicated user, assign permissions policy for created buckets, and add an access key, 
+displaying it at the end so it can be copied to the validator `.env` file. 
+
+If you don't want to create a user and prefer to handle permissions manually, just skip the `--create-user` option.
 
 Note: if your buckets are not in your default AWS region export `AWS_DEFAULT_REGION` before running the script (both buckets needs to be in the same region), and add it to `.env` later:
 ```
@@ -99,7 +103,7 @@ If you used `--create-user` flag, it will also show the values for `AWS_ACCESS_K
 You have to copy these variables in your validator `.env` file and restart your validator.
 
 > [!WARNING]  
-> If you did not use `--create-user`, you still need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your validator .env file.
+> If you did not use `--create-user`, you still need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your validator `.env` file.
 > In that case, you will have to manually generate the credentials.
 
 > [!NOTE]
@@ -117,5 +121,5 @@ TRUSTED_MINER_PORT = MINER_PORT
 If your buckets are not in the default AWS region, add also:
 
 ```
-AWS_DEFAULT_REGION = BUCKETS_REGION
+AWS_DEFAULT_REGION=BUCKETS_REGION
 ```

--- a/validator/README.md
+++ b/validator/README.md
@@ -96,23 +96,23 @@ Replace `PROMPTS_BUCKET` and `ANSWERS_BUCKET` with the names of the S3 buckets y
 It will automatically create a dedicated user, assign permissions policy for created buckets, and add an access key, 
 displaying it at the end so it can be copied to the validator `.env` file. 
 
-If you don't want to create a user and prefer to handle permissions manually, just skip the `--create-user` option.
+If you don't want to create a user and prefer to handle permissions manually, skip the `--create-user` option.
 
-Note: if your buckets are not in your default AWS region export `AWS_DEFAULT_REGION` before running the script (both buckets needs to be in the same region), and add it to `.env` later:
+Note: if your buckets are not in your default AWS region export `AWS_DEFAULT_REGION` before running the script (both buckets need to be in the same region), and add it to `.env` later:
 ```
 export AWS_DEFAULT_REGION=BUCKETS_REGION
 ```
 
 At the end of the script, it will show the values for `S3_BUCKET_NAME_PROMPTS`, `S3_BUCKET_NAME_ANSWERS`.
-If you used `--create-user` flag, it will also show the values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-You have to copy these variables in your validator `.env` file and restart your validator.
+If you use the `--create-user` flag, it will also show the values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+opy these variables in your validator `.env` file and restart your validator.
 
 > [!WARNING]  
 > If you did not use `--create-user`, you still need to provide `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your validator `.env` file.
 > In that case, you will have to manually generate the credentials.
 
 > [!NOTE]
-> We have tested the AWS S3. The buckets are used to allow quick and concurrent upload and download of multiple (but tiny) text files.
+> We have tested the AWS S3. The buckets allow quick and concurrent upload and download of multiple (but tiny) text files.
 
 ## Updated validator .env
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -62,9 +62,9 @@ REMOTE_CELERY_START_SCRIPT=/project/mount/ComputeHorde/validator/dev_env_setup/s
 DEBUG_MINER_KEY=... python manage.py debug_run_synthetic_jobs
 ```
 
-## Setting up a trusted miner for cross-validation
+# Setting up a trusted miner for cross-validation
 
-### Set up a server
+## Set up a server
 
 Create an Ubuntu server and use the `install_miner.sh` script from the root of this repository to install the miner in a **local mode**:
 
@@ -78,7 +78,7 @@ Replace the placeholders in the command above:
 - `MINER_PORT` (optional): the port (of your choosing) on which the miner will listen for incoming connections (default is 8000)
 - `DEFAULT_EXECUTOR_CLASS` (optional): specify a custom executor class to use; set **`always_on.llm.a6000` is mandatory to support A6000 synthetic job flow** 
 
-### Provision S3 buckets for prompts and answers
+## Provision S3 buckets for prompts and answers
 
 Trusted miners require S3 buckets to store prompts and answers. 
 
@@ -114,7 +114,7 @@ You have to copy these variables in your validator `.env` file and restart your 
 > [!NOTE]
 > We have tested the AWS S3. The buckets are used to allow quick and concurrent upload and download of multiple (but tiny) text files.
 
-### Updated validator .env
+## Updated validator .env
 
 Add or update these variables in the validator `.env` file:
 


### PR DESCRIPTION
In this PR
- [x] make trusted miner and buckets setup steps more visible
- [x] more elaborate description on KEY arguments to miner and validator scripts
- [x] more elaborate mention that the miner port is to be chosen by the user
- [x] restructure here and there to show the steps in a more visible way
- [x] stress the location of the running of the scripts