### PR TITLE
point pip in vendor scripts to install stuff in the venv

### DIFF
--- a/miner/app/envs/prod/Dockerfile
+++ b/miner/app/envs/prod/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
 WORKDIR /root/src/
 ENV PYTHONUNBUFFERED=1
 ENV PATH="/root/src/.venv/bin:$PATH"
+ENV PIP_PREFIX="/root/src/.venv"
 
 COPY --from=base-image /root/src/ /root/src/
 


### PR DESCRIPTION
After migrating to uv, packages get installed in .venv in the sources directory, not globally.

This tells pip to install things in the same .venv as other app dependencies, fixing miner vendor scripts.