### PR TITLE
Prepare executor for SN21 integration

### DIFF
--- a/compute_horde/compute_horde/executor_class.py
+++ b/compute_horde/compute_horde/executor_class.py
@@ -68,8 +68,6 @@ EXECUTOR_CLASS = {
 }
 
 
-# we split 144min 2 tempos window to 24 validators - this is total time after reservation,
-# validator may wait spin_up time of executor class to synchronize running synthetic batch
 MAX_EXECUTOR_TIMEOUT = timedelta(minutes=20).total_seconds()
 
 DEFAULT_EXECUTOR_CLASS = ExecutorClass.spin_up_4min__gpu_24gb

--- a/compute_horde/compute_horde/executor_class.py
+++ b/compute_horde/compute_horde/executor_class.py
@@ -70,7 +70,7 @@ EXECUTOR_CLASS = {
 
 # we split 144min 2 tempos window to 24 validators - this is total time after reservation,
 # validator may wait spin_up time of executor class to synchronize running synthetic batch
-MAX_EXECUTOR_TIMEOUT = timedelta(minutes=6).total_seconds()
+MAX_EXECUTOR_TIMEOUT = timedelta(minutes=20).total_seconds()
 
 DEFAULT_EXECUTOR_CLASS = ExecutorClass.spin_up_4min__gpu_24gb
 DEFAULT_LLM_EXECUTOR_CLASS = ExecutorClass.always_on__llm__a6000

--- a/executor/app/src/compute_horde_executor/executor/management/commands/run_executor.py
+++ b/executor/app/src/compute_horde_executor/executor/management/commands/run_executor.py
@@ -66,10 +66,10 @@ from compute_horde_executor.executor.output_uploader import OutputUploader, Outp
 logger = logging.getLogger(__name__)
 
 CVE_2022_0492_TIMEOUT_SECONDS = 120
-MAX_RESULT_SIZE_IN_RESPONSE = 1000
-TRUNCATED_RESPONSE_PREFIX_LEN = 100
-TRUNCATED_RESPONSE_SUFFIX_LEN = 100
-INPUT_VOLUME_UNPACK_TIMEOUT_SECONDS = 300
+MAX_RESULT_SIZE_IN_RESPONSE = 2000
+TRUNCATED_RESPONSE_PREFIX_LEN = 1000
+TRUNCATED_RESPONSE_SUFFIX_LEN = 1000
+INPUT_VOLUME_UNPACK_TIMEOUT_SECONDS = 60 * 15
 CVE_2022_0492_IMAGE = (
     "us-central1-docker.pkg.dev/twistlock-secresearch/public/can-ctr-escape-cve-2022-0492:latest"
 )
@@ -486,7 +486,10 @@ class JobRunner:
         self.volume_mount_dir.mkdir(exist_ok=True)
         self.output_volume_mount_dir.mkdir(exist_ok=True)
 
+        logger.info("preparing in progress")
+
         if self.initial_job_request.base_docker_image_name is not None:
+            logger.info("docker pull %s", self.initial_job_request.base_docker_image_name)
             process = await asyncio.create_subprocess_exec(
                 "docker",
                 "pull",
@@ -495,6 +498,9 @@ class JobRunner:
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await process.communicate()
+
+            logger.info(stderr.decode())
+            logger.info(stdout.decode())
 
             if process.returncode != 0:
                 msg = (
@@ -898,6 +904,7 @@ class Command(BaseCommand):
                 try:
                     await job_runner.prepare()
                 except JobError:
+                    logger.exception("Prepare error")
                     await miner_client.send_failed_to_prepare()
                     return
 

--- a/miner/app/src/compute_horde_miner/miner/executor_manager/_internal/base.py
+++ b/miner/app/src/compute_horde_miner/miner/executor_manager/_internal/base.py
@@ -84,6 +84,7 @@ class ExecutorClassPool:
             if status is not None:
                 return reserved_executor, True
             elif reserved_executor.is_expired():
+                logger.warning("Executor timed out, killing it.")
                 await self.manager.kill_executor(reserved_executor.executor)
                 return reserved_executor, True
             return reserved_executor, False

--- a/miner/app/src/compute_horde_miner/miner/executor_manager/_internal/docker.py
+++ b/miner/app/src/compute_horde_miner/miner/executor_manager/_internal/docker.py
@@ -101,6 +101,8 @@ class DockerExecutorManager(BaseExecutorManager):
 
     async def kill_executor(self, executor):
         # kill executor container first so it would not be able to report anything - job simply timeouts
+        logger.info("Stopping executor %s", executor.token)
+
         process = await asyncio.create_subprocess_exec("docker", "stop", executor.token)
         try:
             await asyncio.wait_for(process.wait(), timeout=DOCKER_STOP_TIMEOUT)


### PR DESCRIPTION
Changes summary:

- Increase executor timeouts (that's required as 6 min is too low for SN21 jobs, it needs at least 12–15 min on A6000). I'm open to adjusting the values or doing it some better way.
- Add Adal's Huggingface download optimization env var to dev executor class
- Add more logging to executor (that includes job's stdout and stderr, if that's too much I can remove it)
- Add more logging to executor manager, including when executors are killed, it wasn't clear to me what's happening and why