### PR TITLE
Allow specifying files to download in HuggingfaceVolume

### DIFF
--- a/compute_horde/compute_horde/base/volume.py
+++ b/compute_horde/compute_horde/base/volume.py
@@ -23,9 +23,12 @@ class VolumeType(str, enum.Enum):
 class HuggingfaceVolume(pydantic.BaseModel):
     volume_type: Literal[VolumeType.huggingface_volume] = VolumeType.huggingface_volume
     repo_id: str
+    # Set to "dataset" or "space" for a dataset or space, None or "model" for a model.
     repo_type: str | None = None
-    revision: str | None = None  # Git revision id: branch name / tag / commit hash
+    # Git revision id: branch name / tag / commit hash
+    revision: str | None = None
     relative_path: str | None = None
+    # If provided, only files matching at least one pattern are downloaded.
     allow_patterns: str | list[str] | None = None
 
     def is_safe(self) -> bool:

--- a/compute_horde/compute_horde/base/volume.py
+++ b/compute_horde/compute_horde/base/volume.py
@@ -23,8 +23,10 @@ class VolumeType(str, enum.Enum):
 class HuggingfaceVolume(pydantic.BaseModel):
     volume_type: Literal[VolumeType.huggingface_volume] = VolumeType.huggingface_volume
     repo_id: str
+    repo_type: str | None = None
     revision: str | None = None  # Git revision id: branch name / tag / commit hash
     relative_path: str | None = None
+    allow_patterns: str | list[str] | None = None
 
     def is_safe(self) -> bool:
         return True

--- a/executor/app/src/compute_horde_executor/executor/management/commands/run_executor.py
+++ b/executor/app/src/compute_horde_executor/executor/management/commands/run_executor.py
@@ -386,14 +386,21 @@ class DownloadManager:
         self.max_retries = max_retries
 
     def download_from_huggingface(
-        self, relative_path: pathlib.Path, repo_id: str, revision: str | None
+        self,
+        relative_path: pathlib.Path,
+        repo_id: str,
+        revision: str | None,
+        repo_type: str | None = None,
+        allow_patterns: str | list[str] | None = None,
     ):
         try:
             snapshot_download(
                 repo_id=repo_id,
+                repo_type=repo_type,
                 revision=revision,
                 token=settings.HF_ACCESS_TOKEN,
                 local_dir=relative_path,
+                allow_patterns=allow_patterns,
             )
         except Exception as e:
             logger.error(f"Failed to download model from Hugging Face: {e}")
@@ -791,7 +798,11 @@ class JobRunner:
             if volume.relative_path:
                 extraction_path /= volume.relative_path
             await sync_to_async(self.download_manager.download_from_huggingface)(
-                extraction_path, volume.repo_id, volume.revision
+                relative_path=extraction_path,
+                repo_id=volume.repo_id,
+                revision=volume.revision,
+                repo_type=volume.repo_type,
+                allow_patterns=volume.allow_patterns,
             )
 
     async def _unpack_single_file_volume(self, volume: SingleFileVolume):


### PR DESCRIPTION
For SN21 integration we want to be able download some files from a huge dataset repo without having to download the entire repository. I added two things to make it possible:

*  `repo_type`: must be `"dataset"` for dataset repositories, otherwise it doesn't work. Can be left as `None` for our current usage (models).
* `allow_patterns`: this is passed as-is to the hugginface_hub function. I use it to specify the list of files that I need, but I left the original signature (`str | list[str]`) because we might want to specify a single pattern at some point, I saw something like that in the SDK design issue.

