### PR TITLE
Add strip() to settings.FACILITATOR_URI

### DIFF
--- a/validator/app/src/compute_horde_validator/settings.py
+++ b/validator/app/src/compute_horde_validator/settings.py
@@ -625,7 +625,9 @@ SYNTHETIC_JOB_GENERATOR_FACTORY = env.str(
     "SYNTHETIC_JOB_GENERATOR_FACTORY",
     default="compute_horde_validator.validator.synthetic_jobs.generator.factory:DefaultSyntheticJobGeneratorFactory",
 )
-FACILITATOR_URI = env.str("FACILITATOR_URI", default="wss://facilitator.computehorde.io/ws/v0/")
+FACILITATOR_URI = env.str(
+    "FACILITATOR_URI", default="wss://facilitator.computehorde.io/ws/v0/"
+).strip()
 STATS_COLLECTOR_URL = env.str(
     "STATS_COLLECTOR_URL", default="https://facilitator.computehorde.io/stats_collector/v0/"
 )


### PR DESCRIPTION
I did something like this in `.env`:

```env
FACILITATOR_URI=ws://localhost:8000/ws/v0/ # wss://staging.facilitator.computehorde.io/ws/v0/
```

This resulted in a space on the end of the URI, which in turn caused some hard-to debug errors (400 Bad Request, no explanation in response or logs) when trying to connect to the facilitator. I wasted some time on that so maybe this `.strip()` is not a bad idea.