### PR TITLE
Improve some tests of compute_horde

### DIFF
--- a/compute_horde/tests/conftest.py
+++ b/compute_horde/tests/conftest.py
@@ -1,5 +1,4 @@
 import datetime
-import uuid
 
 import bittensor
 import pytest
@@ -99,8 +98,3 @@ def receipts(validator_keypair, miner_keypair):
 def mocked_responses():
     with responses.RequestsMock() as rsps:
         yield rsps
-
-
-@pytest.fixture(scope="session")
-def container_name():
-    return str(uuid.uuid4())

--- a/compute_horde/tests/test_certificate.py
+++ b/compute_horde/tests/test_certificate.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import subprocess
+import sys
 import uuid
 
 import pytest
@@ -102,6 +103,7 @@ def cleanup_docker(container_name):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform != "linux", reason="requires linux")
 async def test_certificates_with_nginx__success(tmp_path, container_name, cleanup_docker):
     _, public_key, cert = generate_certificate_at(tmp_path)
     nginx_cert_path, _ = await start_nginx_with_certificates(
@@ -114,6 +116,7 @@ async def test_certificates_with_nginx__success(tmp_path, container_name, cleanu
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform != "linux", reason="requires linux")
 async def test_certificates_with_nginx__no_cert(tmp_path, container_name, cleanup_docker):
     _, public_key, _ = generate_certificate_at(tmp_path)
     nginx_cert_path, _ = await start_nginx_with_certificates(
@@ -127,6 +130,7 @@ async def test_certificates_with_nginx__no_cert(tmp_path, container_name, cleanu
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform != "linux", reason="requires linux")
 async def test_certificates_with_nginx__fail(tmp_path, container_name, cleanup_docker):
     _, public_key, _ = generate_certificate_at(tmp_path)
     _ = await start_nginx_with_certificates(NGINX_CONF, public_key, NGINX_PORT, container_name)

--- a/compute_horde/tests/test_certificate.py
+++ b/compute_horde/tests/test_certificate.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+import subprocess
+import uuid
 
 import pytest
 import requests
@@ -87,17 +89,20 @@ async def start_nginx_with_certificates(
     return cert
 
 
-async def cleanup_docker(container_name):
-    process = await asyncio.create_subprocess_exec(
-        "docker", "network", "rm", f"{container_name}_network"
-    )
-    await process.wait()
-    process = await asyncio.create_subprocess_exec("docker", "kill", container_name)
-    await process.wait()
+@pytest.fixture
+def container_name():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def cleanup_docker(container_name):
+    yield
+    subprocess.run(["docker", "kill", container_name])
+    subprocess.run(["docker", "network", "rm", f"{container_name}_network"])
 
 
 @pytest.mark.asyncio
-async def test_certificates_with_nginx__success(tmp_path, container_name):
+async def test_certificates_with_nginx__success(tmp_path, container_name, cleanup_docker):
     _, public_key, cert = generate_certificate_at(tmp_path)
     nginx_cert_path, _ = await start_nginx_with_certificates(
         NGINX_CONF, public_key, NGINX_PORT, container_name
@@ -107,11 +112,9 @@ async def test_certificates_with_nginx__success(tmp_path, container_name):
     assert resp.status_code == 200
     assert resp.text.strip() == "Hello World!"
 
-    await cleanup_docker(container_name)
-
 
 @pytest.mark.asyncio
-async def test_certificates_with_nginx__no_cert(tmp_path, container_name):
+async def test_certificates_with_nginx__no_cert(tmp_path, container_name, cleanup_docker):
     _, public_key, _ = generate_certificate_at(tmp_path)
     nginx_cert_path, _ = await start_nginx_with_certificates(
         NGINX_CONF, public_key, NGINX_PORT, container_name
@@ -122,11 +125,9 @@ async def test_certificates_with_nginx__no_cert(tmp_path, container_name):
     # 400 no cert, 403 wrong cert
     assert resp.status_code != 200
 
-    await cleanup_docker(container_name)
-
 
 @pytest.mark.asyncio
-async def test_certificates_with_nginx__fail(tmp_path, container_name):
+async def test_certificates_with_nginx__fail(tmp_path, container_name, cleanup_docker):
     _, public_key, _ = generate_certificate_at(tmp_path)
     _ = await start_nginx_with_certificates(NGINX_CONF, public_key, NGINX_PORT, container_name)
 
@@ -136,5 +137,3 @@ async def test_certificates_with_nginx__fail(tmp_path, container_name):
 
     with pytest.raises(requests.exceptions.SSLError):
         requests.get(NGINX_URI, verify=str(cert_path))
-
-    await cleanup_docker(container_name)

--- a/compute_horde/tests/test_transport.py
+++ b/compute_horde/tests/test_transport.py
@@ -9,11 +9,11 @@ from compute_horde.transport import WSTransport
 
 class WSTestServer:
     host = "localhost"
-    port = 8765
 
-    def __init__(self):
+    def __init__(self, port: int) -> None:
         self.ws_server: websockets.Server | None = None
         self.received: asyncio.Queue[str] = asyncio.Queue()
+        self.port = port
 
     async def srv(self, ws: websockets.ServerConnection):
         async for message in ws:
@@ -48,16 +48,16 @@ class WSTestServer:
 
 
 @pytest_asyncio.fixture
-async def server():
-    async with WSTestServer() as _server:
+async def server(unused_tcp_port):
+    async with WSTestServer(port=unused_tcp_port) as _server:
         yield _server
 
 
 @pytest.fixture
-def ws_transport():
+def ws_transport(server):
     return WSTransport(
         "test",
-        f"ws://{WSTestServer.host}:{WSTestServer.port}",
+        f"ws://{server.host}:{server.port}",
         base_retry_delay=0.1,
         retry_jitter=0.1,
     )


### PR DESCRIPTION
- skip certificate nginx container tests on non-linux platforms
- properly cleanup containers on failed tests
- make transport tests pick random ports, so they are parallelizable (in case we decide to use `pytest-xdist` in the future)