### PR TITLE
Fix DEBUG-level logs spamming in django shell

### DIFF
--- a/executor/app/src/compute_horde_executor/settings.py
+++ b/executor/app/src/compute_horde_executor/settings.py
@@ -262,6 +262,12 @@ LOGGING = {
             "level": "INFO",
             "propagate": True,
         },
+        # Fix spamming DEBUG-level logs in manage.py shell and shell_plus.
+        "parso": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
     },
 }
 

--- a/miner/app/src/compute_horde_miner/settings.py
+++ b/miner/app/src/compute_horde_miner/settings.py
@@ -373,6 +373,12 @@ LOGGING = {
             "level": "INFO",
             "propagate": True,
         },
+        # Fix spamming DEBUG-level logs in manage.py shell and shell_plus.
+        "parso": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
     },
 }
 

--- a/validator/app/src/compute_horde_validator/settings.py
+++ b/validator/app/src/compute_horde_validator/settings.py
@@ -629,6 +629,12 @@ LOGGING = {
             "level": "WARNING",
             "propagate": True,
         },
+        # Fix spamming DEBUG-level logs in manage.py shell and shell_plus.
+        "parso": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
     },
 }
 


### PR DESCRIPTION
When trying to write something in Django shell, DEBUG-level logs from some ipython parser appear during autocomplete (tab) and wreck the console like:

```python
In [1]: Validator.obDEBUG 2025-02-12 14:25:51,173 parso.python.diff diff parser start
DEBUG 2025-02-12 14:25:51,173 parso.python.diff line_lengths old: 1; new: 1
DEBUG 2025-02-12 14:25:51,173 parso.python.diff -> code[replace] old[1:1] new[1:1]
DEBUG 2025-02-12 14:25:51,173 parso.python.diff parse_part from 1 to 1 (to 0 in part parser)
DEBUG 2025-02-12 14:25:51,173 parso.python.diff diff parser end
```

To reproduce, run `uv run app/src/manage.py shell_plus` (or `shell`) in any of our apps and try to autocomplete something.
Fixed by changing log level of the parser lib to INFO.