### PR TITLE
Fix DEBUG-level logs spamming in facilitator django shell

### DIFF
--- a/facilitator/app/src/project/settings.py
+++ b/facilitator/app/src/project/settings.py
@@ -368,6 +368,12 @@ LOGGING = {
             "level": "INFO",
             "propagate": True,
         },
+        # Fix spamming DEBUG-level logs in manage.py shell and shell_plus.
+        "parso": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
     },
 }
 

--- a/facilitator/uv.lock
+++ b/facilitator/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = "==3.11.*"
 resolution-markers = [
     "sys_platform == 'linux'",
@@ -1206,7 +1205,6 @@ requires-dist = [
     { name = "celery", specifier = "~=5.3.1" },
     { name = "channels", extras = ["daphne"], specifier = ">=4.0.0" },
     { name = "channels-redis", specifier = ">=4.2.0" },
-    { name = "compute-horde", specifier = ">=0.0.23" },
     { name = "compute-horde", editable = "../compute_horde" },
     { name = "crispy-bootstrap5", specifier = ">=2024.2" },
     { name = "django", specifier = "~=4.2.4" },


### PR DESCRIPTION
Same as #411, I didn't do it in facilitator then because I never saw this error but now I did.

> When trying to write something in Django shell, DEBUG-level logs from some ipython parser appear during autocomplete (tab) and wreck the console like:
> 
> ```python
> In [1]: Validator.obDEBUG 2025-02-12 14:25:51,173 parso.python.diff diff parser start
> DEBUG 2025-02-12 14:25:51,173 parso.python.diff line_lengths old: 1; new: 1
> DEBUG 2025-02-12 14:25:51,173 parso.python.diff -> code[replace] old[1:1] new[1:1]
> DEBUG 2025-02-12 14:25:51,173 parso.python.diff parse_part from 1 to 1 (to 0 in part parser)
> DEBUG 2025-02-12 14:25:51,173 parso.python.diff diff parser end
> ```
> To reproduce, run uv run app/src/manage.py shell_plus (or shell) in any of our apps and try to autocomplete something.
> Fixed by changing log level of the parser lib to INFO.