### PR TITLE
Fix InlineVolume printing long contents in logs

### DIFF
--- a/compute_horde/compute_horde/base/volume.py
+++ b/compute_horde/compute_horde/base/volume.py
@@ -37,7 +37,7 @@ class HuggingfaceVolume(pydantic.BaseModel):
 
 class InlineVolume(pydantic.BaseModel):
     volume_type: Literal[VolumeType.inline] = VolumeType.inline
-    contents: str
+    contents: str = Field(repr=False)
     relative_path: str | None = None
 
     def is_safe(self) -> bool:

--- a/compute_horde_sdk/src/_compute_horde_models/volume.py
+++ b/compute_horde_sdk/src/_compute_horde_models/volume.py
@@ -38,7 +38,7 @@ class HuggingfaceVolume(pydantic.BaseModel):
 
 class InlineVolume(pydantic.BaseModel):
     volume_type: Literal[VolumeType.inline] = VolumeType.inline
-    contents: str
+    contents: str = pydantic.Field(repr=False)
     relative_path: str | None = None
 
     def is_safe(self) -> bool:


### PR DESCRIPTION
It looked like this, but much much longer:
```
type='job.new' message_type='V2JobRequest' signature=None uuid='asdkojas' executor_class=<ExecutorClass.always_on__gpu_24gb: 'always_on.gpu-24gb'> docker_image='derp' raw_script='bash' args=[] env={} use_gpu=True volume=InlineVolume(volume_type=<VolumeType.inline: 'inline'>, contents='mc/oeqGkOXnPJJspwN/BN6EoO4A2PLYjgqyq8YZE663IZE/bMnJazKDzWwH1LCjol5+PAsmFtDh1aGM/YDRNCwcccBXBdoeI3+DQuLUdjNMDQNZ6DO7slPazafKXZFe0jCQukvlIqP5EDaxBSuHMNc9eVCem4i2MBQhlmXxKsmh1HX2fNQNeU7P2ttPAI+50NEDL0sgNBYEZImmyDjtWR5CYvNKt/S3oX/BqpSD9rULXOdI6vy2qjKVBr3cMomCo0Nl+bmZDQc+4YKCKu+Q2sDOzDaZu16yRGW2UaXTYErVFxrXXP8S3TQBRgc0UaAUzxEJXI1snh+JMvGSvHiDuvdx0lflL8prKevxM+cYd6tOx956J+cx+08thwrNoOV3B/ansgr4oE3/bXvOzTFz4fIvWYkycSvAyJXV1jOZs65zh38/2QmVasfuOcXh0VFoqy0F0WMA/iVBqjVUh+v5EKl30Vmfs6IL2r613fX3v011gMfTlBW03yVrjrmxSxlZsn3aAIHsvtNFRY4d4yadaweVlZWcNV6aafV+kVT503WDWPgWvtvCqCH8PYwA17eXKbvJTkB2M5stYG5G/o4/u1bxBsapttKxZ6c9vMGBZFm6bgTaZzryukLRaqSlcb8oqSd8LHA4UiaQZUGQWYyjRHvEsswPgtXn9AK9wOnwO8OPlw0mW0wr2NmRUrilwFWbZeI7NQ4Wem1TvZwVfB5a65OZScg44yaHg50s861SoiQVb86cLz6twXstjglotQRoyrb47nOPiADWLtUn0r29eGBQdRqWpJM8hzG6ngi8KCN2ML2YdNFot3wlHTBzNvUCLLIzG1ZdXe9fDx+FGgwf9Oepx6/rP+4/vxelgtV1y2iFo0rL/5XQtxZQklKpqjlzU9h2c+zDnJKOEHC67HIhSYMDD75paVfGxhXrUckF9Qt08CP4EDwSpB99P6uz99yeV5103ouoUOYsUIzXCFEds1AzQ8Fa6z1/UEvrvowf3PLjx940yG9l3pqHa35uxp1kEvNI74QBVgnH6cXYB+XXNojs9Am5L8YUpEg9eMscx/ivjnfLMMIZU1rThHSpIzI7cuGnna1/ZLcvElDnDFY9HcF5YnS7YG/PmeEK+5szRSbKxBXznxmFYUEPX/VDNGwewrQ1mfPFLrMnAgPJHkSYQrhqPjLOfCnRGpGylZ+CMkDmWmevMte55HM+qQs+xqdAVoyR+MGZJ4dPHMr+CrZ3s4CiyIZJnJjF9b9PPUFVQ98czY9tj9zY6DXOjC5IUARJvXr2ENr712q5NwnQw+Ph03utmhHnLxnRZSI+aNyxbOyzqYNbfcDKL1Q==', relative_path=None) output_upload=None artifacts_dir=None

```

Ref: https://docs.pydantic.dev/latest/concepts/fields/#field-representation