### PR TITLE
Improve validator logging on websocket error

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
@@ -136,11 +136,7 @@ class FacilitatorClient:
                     await self.handle_connection(ws)
                 except websockets.ConnectionClosed as exc:
                     self.ws = None
-                    logger.warning(
-                        "validator connection closed with code %r and reason %r, reconnecting...",
-                        exc.code,
-                        exc.reason,
-                    )
+                    logger.warning("validator connection closed: %s, reconnecting...", exc)
                 except asyncio.exceptions.CancelledError:
                     self.ws = None
                     logger.warning("Facilitator client received cancel, stopping")


### PR DESCRIPTION
`code` and `reason` are deprecated and provide misleading info. The exception class now has a `__str__` method that seems to work much better here.

Before:
```
validator connection closed with code <CloseCode.ABNORMAL_CLOSURE: 1006> and reason '', reconnecting...
```
Now:
```
validator connection closed: sent 1009 (message too big) frame with 1070709 bytes exceeds limit of 1048576 bytes; no close frame received, reconnecting...
```