### PR TITLE
SDK: add zip compression to inline volumes

### DIFF
--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/models.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/models.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
+from typing import Literal, Self
 
 import pydantic
 
@@ -103,9 +103,11 @@ class InlineInputVolume(pydantic.BaseModel, AbstractInputVolume):
         )
 
     @classmethod
-    def from_file_contents(cls, filename: str, contents: bytes):
+    def from_file_contents(cls, filename: str, contents: bytes, compress: bool = False) -> Self:
         in_memory_output = io.BytesIO()
-        zipf = zipfile.ZipFile(in_memory_output, "w")
+        zipf = zipfile.ZipFile(
+            in_memory_output, "w", compression=zipfile.ZIP_DEFLATED if compress else zipfile.ZIP_STORED
+        )
         zipf.writestr(filename, contents)
         zipf.close()
         in_memory_output.seek(0)


### PR DESCRIPTION
We had problems where the inline volumes exceeded 1 MB, compression brings that down (for that particular use case) to 0.27 MB, which is useful for SN15 validation.

Unpacking them works as-is, no changes needed.