### PR TITLE
Fix organic job volumes being sent twice

### DIFF
--- a/compute_horde/compute_horde/miner_client/organic.py
+++ b/compute_horde/compute_horde/miner_client/organic.py
@@ -468,7 +468,7 @@ async def run_organic_job(
                     docker_image=job_details.docker_image,
                     docker_run_options_preset=job_details.docker_run_options_preset,
                     docker_run_cmd=job_details.docker_run_cmd,
-                    volume=job_details.volume,
+                    volume=None,  # Was sent in the initial request
                     output_upload=job_details.output,
                     artifacts_dir=job_details.artifacts_dir,
                 )

--- a/validator/app/src/compute_horde_validator/settings.py
+++ b/validator/app/src/compute_horde_validator/settings.py
@@ -388,7 +388,7 @@ CONSTANCE_CONFIG = {
         float,
     ),
     "DYNAMIC_ROUTING_PRELIMINARY_RESERVATION_TIME_SECONDS": (
-        10,
+        10.0,
         "How long to initially reserve an executor for during job routing request. This should last only long enough "
         "for the job flow to create and store a job started receipt.",
         float,


### PR DESCRIPTION
The executor errors out if the volumes are being sent twice. Changed that so that now for organic jobs they are only sent in the Initial job request.

As for the settings change, Constance crashes the entire admin panel because 10 is not a float…