### PR TITLE
COM-522 Ignore ResourceWarning for unclosed redis connections

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/tests/conftest.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/conftest.py
@@ -134,3 +134,15 @@ def validators_with_this_hotkey(settings, validators):
 @pytest.fixture(scope="session")
 def run_uuid():
     return str(uuid.uuid4())
+
+
+# NOTE: Use this fixture when you need to find dangling asyncio tasks. It is currently commented
+#       because redis channels layers keeps dangling tasks, that makes the tests fail -_-
+# @pytest_asyncio.fixture(autouse=True)
+# async def check_still_running_tasks():
+#     yield
+#     tasks = asyncio.all_tasks()
+#     if len(tasks) > 1:
+#         raise ValueError(
+#             "\n" + "\n".join(f"{task.get_name()}: {task.get_coro()}" for task in tasks)
+#         )

--- a/validator/app/src/pytest.ini
+++ b/validator/app/src/pytest.ini
@@ -6,5 +6,5 @@ filterwarnings =
     default::DeprecationWarning
     default:Error when trying to teardown test databases
     ;ignore unclosed socket warnings for redis/postgres ports
-    ignore:unclosed <socket.* raddr=\(.*\b(9379|9432)\b.*\)>$:ResourceWarning
+    ignore:unclosed <socket.* raddr=\(.*\b9379\b.*\)>$:ResourceWarning
 addopts = -s

--- a/validator/app/src/pytest.ini
+++ b/validator/app/src/pytest.ini
@@ -5,4 +5,6 @@ filterwarnings =
     error
     default::DeprecationWarning
     default:Error when trying to teardown test databases
+    ;ignore unclosed socket warnings for redis/postgres ports
+    ignore:unclosed <socket.* raddr=\(.*\b(9379|9432)\b.*\)>$:ResourceWarning
 addopts = -s


### PR DESCRIPTION
I suspected that there are some dangling asyncio tasks that are using redis/postgres connections. I fixed some, but the error still persists. Maybe my suspicions are unfounded and django keeps those connection open anyway? But it is curious that this issue only happens in validator, not in miner or facilitator.

As discussed, I've added ignore flags for these ports.