### PR TITLE
Add retries to huggingface volume downloads, also with hf_transfer disabled

### DIFF
--- a/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
+++ b/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
@@ -297,7 +297,7 @@ def test_huggingface_volume():
     repo_id = "huggingface/model"
     revision = "main"
 
-    with patch("huggingface_hub.snapshot_download", mock_download):
+    with patch("huggingface_hub.snapshot_download", side_effect=mock_download):
         command = CommandTested(
             iter(
                 [
@@ -371,7 +371,9 @@ def test_huggingface_volume_failure():
     repo_id = "huggingface/model"
     revision = "main"
 
-    with patch("huggingface_hub.snapshot_download", mock_download_failure):
+    with patch(
+        "huggingface_hub.snapshot_download", side_effect=mock_download_failure
+    ) as mock_snapshot_download:
         command = CommandTested(
             iter(
                 [
@@ -436,6 +438,96 @@ def test_huggingface_volume_failure():
             "job_uuid": job_uuid,
         },
     ]
+
+    assert mock_snapshot_download.call_count == 3
+
+
+def test_huggingface_volume_fail_and_retry():
+    # Arrange
+    repo_id = "huggingface/model"
+    revision = "main"
+
+    first_try = True
+
+    def side_effect(*args, **kwargs):
+        nonlocal first_try
+        if first_try:
+            first_try = False
+            mock_download_failure(*args, **kwargs)
+        else:
+            mock_download(*args, **kwargs)
+
+    with patch(
+        "huggingface_hub.snapshot_download", side_effect=side_effect
+    ) as mock_snapshot_download:
+        command = CommandTested(
+            iter(
+                [
+                    json.dumps(
+                        {
+                            "message_type": "V0InitialJobRequest",
+                            "executor_class": "spin_up-4min.gpu-24gb",
+                            "docker_image": "backenddevelopersltd/compute-horde-job-echo:v0-latest",
+                            "timeout_seconds": 10,
+                            "volume_type": "huggingface_volume",
+                            "job_uuid": job_uuid,
+                            "job_started_receipt_payload": {
+                                "job_uuid": job_uuid,
+                                "miner_hotkey": "miner_hotkey",
+                                "validator_hotkey": "validator_hotkey",
+                                "timestamp": "2025-01-01T00:00:00+00:00",
+                                "executor_class": "spin_up-4min.gpu-24gb",
+                                "max_timeout": 10,
+                                "is_organic": True,
+                                "ttl": 5,
+                            },
+                            "job_started_receipt_signature": "blah",
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "message_type": "V0JobRequest",
+                            "executor_class": "spin_up-4min.gpu-24gb",
+                            "docker_image": "backenddevelopersltd/compute-horde-job-echo:v0-latest",
+                            "docker_run_cmd": [],
+                            "docker_run_options_preset": "none",
+                            "volume": {
+                                "volume_type": "huggingface_volume",
+                                "repo_id": repo_id,
+                                "revision": revision,
+                            },
+                            "job_uuid": job_uuid,
+                        }
+                    ),
+                ]
+            )
+        )
+
+        # Act
+        command.handle()
+
+    # Assert
+    assert [json.loads(msg) for msg in command.miner_client_for_tests.transport.sent_messages] == [
+        {
+            "message_type": "V0ExecutorReadyRequest",
+            "executor_token": None,
+            "job_uuid": job_uuid,
+        },
+        {
+            "message_type": "V0MachineSpecsRequest",
+            "specs": mock.ANY,
+            "job_uuid": job_uuid,
+        },
+        {
+            "message_type": "V0JobFinishedRequest",
+            "docker_process_stdout": payload,
+            "docker_process_stderr": mock.ANY,
+            "artifacts": {},
+            "job_uuid": job_uuid,
+        },
+    ]
+
+    assert mock_snapshot_download.call_count == 2
 
 
 def test_huggingface_volume_dataset():

--- a/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
+++ b/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
@@ -297,10 +297,7 @@ def test_huggingface_volume():
     repo_id = "huggingface/model"
     revision = "main"
 
-    with patch(
-        "compute_horde_executor.executor.management.commands.run_executor.snapshot_download",
-        mock_download,
-    ):
+    with patch("huggingface_hub.snapshot_download", mock_download):
         command = CommandTested(
             iter(
                 [
@@ -374,10 +371,7 @@ def test_huggingface_volume_failure():
     repo_id = "huggingface/model"
     revision = "main"
 
-    with patch(
-        "compute_horde_executor.executor.management.commands.run_executor.snapshot_download",
-        mock_download_failure,
-    ):
+    with patch("huggingface_hub.snapshot_download", mock_download_failure):
         command = CommandTested(
             iter(
                 [
@@ -434,7 +428,7 @@ def test_huggingface_volume_failure():
         {
             "message_type": "V0JobFailedRequest",
             "docker_process_exit_status": None,
-            "docker_process_stdout": "Failed to download model from Hugging Face: Download failed",
+            "docker_process_stdout": "Failed to download model from Hugging Face after 3 retries: Download failed",
             "docker_process_stderr": "",
             "error_type": V0JobFailedRequest.ErrorType.HUGGINGFACE_DOWNLOAD.value,
             "error_detail": "Download failed",
@@ -461,8 +455,7 @@ def test_huggingface_volume_dataset():
     ]
 
     with patch(
-        "compute_horde_executor.executor.management.commands.run_executor.snapshot_download",
-        side_effect=mock_download,
+        "huggingface_hub.snapshot_download", side_effect=mock_download
     ) as mock_snapshot_download:
         command = CommandTested(
             iter(


### PR DESCRIPTION
Our current SN15 jobs on ComputeHorde prod executors fail with errors like:
```
Failed to download model from Hugging Face: An error occurred while downloading using hf_transfer. Consider disabling HF_HUB_ENABLE_HF_TRANSFER for better error handling.
```

On the other hand, this library is useful when it works, because it can reduce the time to download a model by a lot.

Added retires to HF volume downloads with disabling `hf_transfer` after the first try.

It modifies an internal library constant, which is probably not a great solution, but I don't know how to do it better. Using or not `hf_transfer` is decided by an environment variable on import time and can't be parametrized otherwise.

<details><summary>Test script</summary>

```python
import os
from pathlib import Path

os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "compute_horde_executor.settings")

import django

django.setup()

import hf_transfer

def crash(*args, **kwargs):
    raise Exception("Crash test")

hf_transfer.download = crash

from compute_horde_executor.executor.management.commands.run_executor import DownloadManager

dm = DownloadManager()

dm.download_from_huggingface(Path("./testdir/"), "snx999/dev3", None)
```
</details>