### PR TITLE
Fixing CI

### DIFF
--- a/.github/workflows/compute_horde_sdk_cd_docs.yml
+++ b/.github/workflows/compute_horde_sdk_cd_docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/compute_horde_sdk_cd_docs.yml
+++ b/.github/workflows/compute_horde_sdk_cd_docs.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/compute_horde_sdk_ci.yml
+++ b/.github/workflows/compute_horde_sdk_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -49,7 +49,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -79,7 +79,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox

--- a/.github/workflows/compute_horde_sdk_ci.yml
+++ b/.github/workflows/compute_horde_sdk_ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -47,7 +47,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -77,7 +77,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/compute_horde_sdk_publish.yml
+++ b/.github/workflows/compute_horde_sdk_publish.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/compute_horde_sdk_publish.yml
+++ b/.github/workflows/compute_horde_sdk_publish.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
 
       - name: Build

--- a/.github/workflows/executor_ci.yml
+++ b/.github/workflows/executor_ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -75,7 +75,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/executor_ci.yml
+++ b/.github/workflows/executor_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -51,7 +51,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -77,7 +77,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox

--- a/.github/workflows/facilitator_ci.yml
+++ b/.github/workflows/facilitator_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -56,7 +56,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox

--- a/.github/workflows/facilitator_ci.yml
+++ b/.github/workflows/facilitator_ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -54,7 +54,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/integration_ci.yml
+++ b/.github/workflows/integration_ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/integration_ci.yml
+++ b/.github/workflows/integration_ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Start all services
         run: local_stack/run_and_await_readiness.sh /tmp/integration_test_logs/

--- a/.github/workflows/library_ci.yml
+++ b/.github/workflows/library_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -51,7 +51,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -75,7 +75,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox

--- a/.github/workflows/library_ci.yml
+++ b/.github/workflows/library_ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -73,7 +73,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/miner_ci.yml
+++ b/.github/workflows/miner_ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -75,7 +75,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/miner_ci.yml
+++ b/.github/workflows/miner_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -51,7 +51,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -77,7 +77,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox

--- a/.github/workflows/validator_ci.yml
+++ b/.github/workflows/validator_ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true
@@ -75,7 +75,7 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/validator_ci.yml
+++ b/.github/workflows/validator_ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -51,7 +51,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox
@@ -77,7 +77,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: "latest"
+          version: "0.6.x"
           enable-cache: true
       - name: Install dependencies
         run: python -m pip install --upgrade nox


### PR DESCRIPTION
uv released 0.7, nox broke in CI. This pins uv to an older (0.6) version as a workaround.