### PR TITLE
Make streaming_start_time_limit_sec optional

### DIFF
--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/sdk.py
@@ -54,6 +54,8 @@ RETRYABLE_HTTP_EXCEPTIONS = (
     # httpx.DecodingError,
 )
 
+DEFAULT_STREAMING_START_TIME_LIMIT_SEC = 5
+
 JobAttemptCallbackType: TypeAlias = (
     Callable[["ComputeHordeJob"], None]
     | Callable[["ComputeHordeJob"], Awaitable[None]]
@@ -109,13 +111,6 @@ class ComputeHordeJobSpec:
     stopped, but it won't be considered failed - it will proceed to the upload stage anyway.
     """
 
-    streaming_start_time_limit_sec: int
-    """
-    Time dedicated to starting the streaming server.
-    Part of the paid cost to run the job.
-    If the limit is reached, the job will fail.
-    """
-
     upload_time_limit_sec: int
     """
     Time dedicated to uploading the job's output.
@@ -160,6 +155,13 @@ class ComputeHordeJobSpec:
     (such as address, port, and SSL certificate) will be available
     in the ComputeHordeJob instance after the `wait_for_streaming()`
     method returns.
+    """
+
+    streaming_start_time_limit_sec: int = DEFAULT_STREAMING_START_TIME_LIMIT_SEC
+    """
+    Time dedicated to starting the streaming server.
+    Part of the paid cost to run the job.
+    If the limit is reached, the job will fail.
     """
 
 

--- a/local_stack/send_hello_world_job.py
+++ b/local_stack/send_hello_world_job.py
@@ -147,7 +147,6 @@ async def main() -> None:
         artifacts_dir="/artifacts",
         download_time_limit_sec=5,
         execution_time_limit_sec=10,
-        streaming_start_time_limit_sec=5,
         upload_time_limit_sec=5,
     )
 


### PR DESCRIPTION
Let's make `streaming_start_time_limit_sec` optional parameter and default to 5 seconds. It should not be required since it's only used when running streaming jobs.