### PR TITLE
[sdk docs] Presigned output volume urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The SDK allows you to:
 - Perform **cross-validation** to verify result integrity and protect against malicious miners.
 - **Reduce infrastructure costs** by eliminating the need for physical GPUs.
 - **Accelerate validation** by leveraging ComputeHorde’s ready-to-go GPU pool.
+- **Fallback to other clouds** like [RunPod](https://www.runpod.io/) via SkyPilot if ComputeHorde is temporarily unavailable.
 
 ## Scoring Mechanism
 

--- a/compute_horde_sdk/README.md
+++ b/compute_horde_sdk/README.md
@@ -236,6 +236,17 @@ async for job in client.iter_jobs():
 
 If `job.status` is `"Completed"`, the `job.result` should be available.
 
+## 🛠️ Fallback to RunPod or Other Clouds
+
+If ComputeHorde is temporarily unavailable, you can run your jobs on a fallback cloud provider like [RunPod](https://www.runpod.io/) using [SkyPilot](https://skypilot.co/).
+
+The SDK includes an optional `FallbackClient` that mirrors the standard `ComputeHordeClient` interface.
+
+> 📦 Install with extras:
+> `pip install compute-horde-sdk[fallback]`
+
+See the [Fallback docs](https://sdk.computehorde.io/master/fallback.html) for usage examples and limitations.
+
 ## Versioning
 
 This package uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/compute_horde_sdk/README.md
+++ b/compute_horde_sdk/README.md
@@ -171,6 +171,38 @@ async def main():
 asyncio.run(main())
 ```
 
+### 📤 Uploading Output to S3 or R2 (Presigned URLs)
+
+ComputeHorde lets you store output files externally using **HTTP PUT or POST uploads** to any S3-compatible service (e.g., AWS S3, Cloudflare R2).
+
+> ⚠️ The SDK **does not** generate presigned URLs for you.
+
+Instead, you must:
+1. Generate presigned POST/PUT URLs using your own code or SDK.
+2. Pass them into `output_volumes` using `HTTPOutputVolume`.
+
+#### Example:
+
+```python
+from compute_horde_sdk.v1 import HTTPOutputVolume
+
+job_spec.output_volumes = {
+    "/output/image.png": HTTPOutputVolume(
+        http_method="PUT",
+        url="https://<your-s3-or-r2-presigned-url>",
+    )
+}
+```
+
+You can also include POST form fields using the `form_fields` dict parameter.
+
+#### ✅ Full Example in the Repo
+
+See [`send_hello_world_job.py`](https://github.com/backend-developers-ltd/ComputeHorde/blob/master/local_stack/send_hello_world_job.py) for a working test that:
+- Generates POST and PUT presigned URLs using `boto3`
+- Submits a job
+- Verifies file upload succeeded
+
 ### 3. **Cross-Validation**
 
 To ensure fairness and detect potential cheating, **cross-validation** should be performed on **1-2% of submitted jobs**. 

--- a/compute_horde_sdk/docs/source/fallback.rst
+++ b/compute_horde_sdk/docs/source/fallback.rst
@@ -70,3 +70,13 @@ If you want to run your job on Runpod in case of any error:
 
 
     asyncio.run(main())
+
+.. note::
+
+    The ``cloud`` argument passed to ``FallbackClient`` is forwarded to SkyPilot. Valid values include:
+    ``"runpod"``, ``"aws"``, ``"gcp"``, and others supported by SkyPilot.
+
+    We officially support ``"runpod"``, but you're welcome to try other providers.
+    If you do, let us know how it goes!
+
+    See the `SkyPilot Cloud Setup Docs <https://skypilot.co/docs/cloud-setup/overview/>`_ for details.

--- a/compute_horde_sdk/docs/source/fallback.rst
+++ b/compute_horde_sdk/docs/source/fallback.rst
@@ -61,7 +61,7 @@ If you want to run your job on Runpod in case of any error:
             fallback_client = FallbackClient("runpod", api_key=environ.get("RUNPOD_API_KEY"))
 
             # Define your fallback job base on the ComputeHorde spec
-            fallback_spec = FallbackJobSpec.from_job_spec(spec, work_dir="/app", region="US")
+            fallback_spec = FallbackJobSpec.from_job_spec(job_spec, work_dir="/app", region="US")
 
             # Run the fallback job
             job = await fallback_client.run_until_complete(fallback_spec)

--- a/compute_horde_sdk/docs/source/quickstart.rst
+++ b/compute_horde_sdk/docs/source/quickstart.rst
@@ -121,6 +121,12 @@ This example demonstrates how to submit a job with additional parameters, includ
 
     asyncio.run(main())
 
+.. note::
+
+    To upload job outputs to S3-compatible storage (e.g., AWS S3, Cloudflare R2),
+    you must generate a presigned URL yourself and pass it to ``HTTPOutputVolume``.
+    See the `send_hello_world_job.py <https://github.com/backend-developers-ltd/ComputeHorde/blob/master/local_stack/send_hello_world_job.py>`_
+    example in the GitHub repo for a full working test.
 
 Managing ComputeHorde Jobs
 --------------------------

--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/fallback/client.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/fallback/client.py
@@ -73,26 +73,21 @@ class FallbackClient:
         """
         Initializes a FallbackClient that can execute jobs using a SkyPilot-managed cloud backend.
 
-        Parameters:
-            cloud (str): The name of the cloud backend to use (e.g. "runpod").
-                         This value is passed directly to SkyPilot. We currently only test
-                         with "runpod", but you are welcome to try the other providers too.
+        :param cloud: The name of the cloud backend to use (e.g. "runpod").
+            This value is passed directly to SkyPilot. We currently only test
+            with "runpod", but you are welcome to try the other providers too.
 
-            idle_minutes (int): How many minutes the fallback instance can remain idle before being shut down.
-                                Defaults to 15 minutes.
+        :param idle_minutes: Number of minutes the fallback instance can remain idle before being shut down.
+            Defaults to 15 minutes.
 
-            **kwargs: Additional keyword arguments forwarded to the SkyPilot `SkyCloud` constructor.
+        :param kwargs: Additional arguments forwarded to the SkyPilot cloud environment setup.
 
-        Raises:
-            ModuleNotFoundError: If the `fallback` extra is not installed.
+        :raises ModuleNotFoundError: If the ``fallback`` extra is not installed.
 
-        Note:
+        .. note::
             You must install the fallback extra with:
 
                 pip install compute-horde-sdk[fallback]
-
-            For more information on available cloud backends and config, see the
-            SkyPilot documentation: https://skypilot.co/docs/cloud-setup/overview/
         """
 
         try:

--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/fallback/client.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/fallback/client.py
@@ -70,6 +70,31 @@ class FallbackClient:
     MAX_ARTIFACT_SIZE = 1_000_000
 
     def __init__(self, cloud: str, idle_minutes: int = 15, **kwargs: Any) -> None:
+        """
+        Initializes a FallbackClient that can execute jobs using a SkyPilot-managed cloud backend.
+
+        Parameters:
+            cloud (str): The name of the cloud backend to use (e.g. "runpod").
+                         This value is passed directly to SkyPilot. We currently only test
+                         with "runpod", but you are welcome to try the other providers too.
+
+            idle_minutes (int): How many minutes the fallback instance can remain idle before being shut down.
+                                Defaults to 15 minutes.
+
+            **kwargs: Additional keyword arguments forwarded to the SkyPilot `SkyCloud` constructor.
+
+        Raises:
+            ModuleNotFoundError: If the `fallback` extra is not installed.
+
+        Note:
+            You must install the fallback extra with:
+
+                pip install compute-horde-sdk[fallback]
+
+            For more information on available cloud backends and config, see the
+            SkyPilot documentation: https://skypilot.co/docs/cloud-setup/overview/
+        """
+
         try:
             self.cloud: SkyCloudType = sky.SkyCloud(cloud, **kwargs)
         except ModuleNotFoundError:

--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/fallback/client.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/fallback/client.py
@@ -88,6 +88,9 @@ class FallbackClient:
             You must install the fallback extra with:
 
                 pip install compute-horde-sdk[fallback]
+
+            For details on available cloud environments, see:
+            https://docs.skypilot.co/en/v0.8.1/overview.html#cloud-vms
         """
 
         try:

--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/models.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/models.py
@@ -217,7 +217,6 @@ class HTTPOutputVolume(pydantic.BaseModel):
     - For **POST** uploads, also include any required form fields using the `form_fields` dictionary.
 
     Examples:
-
     PUT upload:
         HTTPOutputVolume(
             http_method="PUT",
@@ -239,6 +238,7 @@ class HTTPOutputVolume(pydantic.BaseModel):
     Note:
         The SDK does **not** generate presigned URLs for you. Use tools like `boto3`, or your S3 provider’s SDK
         to generate the required `url` and optional `form_fields`.
+
     """
 
     http_method: Literal["POST", "PUT"]

--- a/compute_horde_sdk/src/compute_horde_sdk/_internal/models.py
+++ b/compute_horde_sdk/src/compute_horde_sdk/_internal/models.py
@@ -208,7 +208,38 @@ InputVolume = InlineInputVolume | HuggingfaceInputVolume | HTTPInputVolume
 
 
 class HTTPOutputVolume(pydantic.BaseModel):
-    """Volume for uploading files to the Internet via HTTP."""
+    """
+    Volume for uploading files to the Internet via HTTP.
+
+    Supports both HTTP PUT and POST uploads.
+
+    - For **PUT** uploads, provide the full presigned URL using the `url` parameter.
+    - For **POST** uploads, also include any required form fields using the `form_fields` dictionary.
+
+    Examples:
+
+    PUT upload:
+        HTTPOutputVolume(
+            http_method="PUT",
+            url="https://<your-presigned-url>"
+        )
+
+    POST upload:
+        HTTPOutputVolume(
+            http_method="POST",
+            url="https://<your-presigned-post-url>",
+            form_fields={
+                "key": "example.txt",
+                "policy": "<base64-policy>",
+                "signature": "<signature>",
+                "AWSAccessKeyId": "<access-key-id>"
+            }
+        )
+
+    Note:
+        The SDK does **not** generate presigned URLs for you. Use tools like `boto3`, or your S3 provider’s SDK
+        to generate the required `url` and optional `form_fields`.
+    """
 
     http_method: Literal["POST", "PUT"]
     """HTTP method to use, can be POST or PUT."""


### PR DESCRIPTION
In this PR:
- [x] Presigned urls are mentioned:
  - [x] in quickstart
  - [x] in HTTPOutputVolume docstring
  - [x] in README
- [x] `send_hello_world_job.py` is mentioned:
  - [x] in quickstart
  - [x] in README   
- [x] fixed fallback code snippet (misnamed `job_spec` variable)
- [x] skypilot fallback config is mentioned:
  - [x] in sdk docs
  - [x] in the FallbackClient docstrings
  - [x] readme