### PR TITLE
Feature flag for disabling allowance checks in organic job routing

### DIFF
--- a/validator/app/src/compute_horde_validator/settings.py
+++ b/validator/app/src/compute_horde_validator/settings.py
@@ -422,6 +422,12 @@ CONSTANCE_CONFIG = {
         "Whether organic jobs can be scheduled to run for longer than the current cycle",
         bool,
     ),
+    "DYNAMIC_CHECK_ALLOWANCE_WHILE_ROUTING": (
+        True,
+        "Whether to check for remaining allowance while picking a miner for an organic job. "
+        "In both cases allowance will still be deducted.",
+        bool,
+    ),
 }
 
 # Content Security Policy


### PR DESCRIPTION
Allowance will still be deducted and potentially end up negative.