### PR TITLE
Fix manifest polling

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/tasks.py
+++ b/validator/app/src/compute_horde_validator/validator/tasks.py
@@ -2147,7 +2147,9 @@ async def _poll_miner_manifests() -> None:
                 m
                 async for m in MinerManifest.objects.filter(
                     miner=miner,
-                ).order_by("-created_at")
+                )
+                .distinct("executor_class")
+                .order_by("executor_class", "-created_at")
             ]
 
             if last_manifests:


### PR DESCRIPTION
If miner does not respond with the manifest, we want to copy only the latest manifest, not all of them. This PR fixes the issue with the fallback query, and adds a test to make sure we will not regress in the future.