### PR TITLE
Fallback client - re-use ssh key in CI

### DIFF
--- a/.github/workflows/integration_ci_fallback.yml
+++ b/.github/workflows/integration_ci_fallback.yml
@@ -34,6 +34,14 @@ jobs:
           version: "0.6.x"
           enable-cache: true
 
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.RUNPOD_TEST_PRIVATE_KEY }}" > ~/.ssh/sky-key
+          chmod 600 ~/.ssh/sky-key
+          echo "${{ secrets.RUNPOD_TEST_PUBLIC_KEY }}" > ~/.ssh/sky-key.pub
+          chmod 644 ~/.ssh/sky-key.pub
+
       - name: configure runpod
         working-directory: ./local_stack
         run: uv run runpod config ${{ env.RUNPOD_API_KEY }}


### PR DESCRIPTION
Fallback client creates and uploads a fresh ssh key if `~/.ssh/sky-key` is not available. So after each test run in CI, we were appending the list of configured RunPod ssh keys until we reached a limit of 65000 characters. This PR configures our CI to re-use ssh key in the fallback tests.