### PR TITLE
Fix main hotkey querying

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/scoring/main_hotkey_querying.py
+++ b/validator/app/src/compute_horde_validator/validator/scoring/main_hotkey_querying.py
@@ -100,9 +100,6 @@ async def _query_single_miner(miner: Miner) -> str | None:
                     elif isinstance(msg, GenericError):
                         logger.warning(f"Error from {miner.hotkey}: {msg.details}")
                         return None
-                    else:
-                        logger.warning(f"Unexpected message type from {miner.hotkey}: {type(msg)}")
-                        return None
 
     except TimeoutError:
         logger.warning(f"Timeout querying main hotkey from {miner.hotkey}")


### PR DESCRIPTION
The main hotkey query incorrectly assumed that the first message received from a miner would be a response to the `V0MainHotkeyMessage`. but other messages may be sent first - the first message a miner sends after successful validator authentication is the `V0ExecutorManifestRequest`. Let's simply wait until we receive the expected response.