### PR TITLE
Pull up common error types to compute_horde

### DIFF
--- a/compute_horde/compute_horde/job_errors.py
+++ b/compute_horde/compute_horde/job_errors.py
@@ -1,0 +1,86 @@
+import logging
+from typing import Generic, TypeVar
+
+from compute_horde.protocol_consts import HordeFailureReason, JobFailureReason, JobRejectionReason
+from compute_horde.protocol_messages import FailureContext
+
+ReasonType = TypeVar("ReasonType")
+
+logger = logging.getLogger(__name__)
+
+
+class BaseJobError(Exception, Generic[ReasonType]):
+    """
+    Common structure for job-related errors.
+    """
+
+    def __init__(self, message: str, reason: ReasonType, context: FailureContext | None = None):
+        """
+        Parameters:
+            message: str
+                Short message for a human seeing the error somewhere.
+            reason: ReasonType
+                Structured error reason.
+            context: FailureContext | None
+                Optional arbitrary key-value context to be sent along the error.
+                Avoid
+        """
+        super().__init__(message)
+        self.message = message
+        self.reason = reason
+        self.context = context
+
+    def add_context(self, context: FailureContext):
+        if self.context is None:
+            self.context = {**context}
+        else:
+            self.context.update(context)
+
+    def __str__(self):
+        return f"{self.message}, {self.reason=}"
+
+    def __repr__(self):
+        return f"{type(self).__name__}: {str(self)}"
+
+
+class JobRejection(BaseJobError[JobRejectionReason]):
+    def __str__(self):
+        return f"Job rejected ({self.reason}): {self.message} "
+
+
+class JobError(BaseJobError[JobFailureReason]):
+    def __str__(self):
+        return f"Job failed ({self.reason}): {self.message} "
+
+
+class HordeError(BaseJobError[HordeFailureReason]):
+    def __init__(
+        self,
+        message: str,
+        reason: HordeFailureReason = HordeFailureReason.GENERIC_ERROR,
+        context: FailureContext | None = None,
+    ):
+        super().__init__(message, reason, context)
+
+    def __str__(self):
+        return f"Horde failed ({self.reason}): {self.message}"
+
+    @classmethod
+    def wrap_unhandled(cls, e: Exception, context: FailureContext | None = None) -> "HordeError":
+        """
+        Intended for "catch-all" except blocks - consistently wraps the exception in a HordeError.
+        For catching errors somewhere in the job code, do instead:
+            `raise HordeError("Spline reticulation failed") from e`
+        """
+        if isinstance(e, HordeError):
+            # Don't wrap another horde failure
+            return e
+
+        if isinstance(e, BaseJobError):
+            # If another job error is to be wrapped by accident - don't blow up, but scream for help
+            logger.error(f"Wrapping a {type(e).__qualname__} in a HordeError", exc_info=False)
+
+        failure = cls("Unhandled exception", HordeFailureReason.UNHANDLED_EXCEPTION, context)
+        failure.__cause__ = e
+        failure.add_context({"exception_type": type(e).__qualname__})
+        return failure

--- a/compute_horde/compute_horde/protocol_messages.py
+++ b/compute_horde/compute_horde/protocol_messages.py
@@ -29,7 +29,7 @@ from compute_horde.utils import MachineSpecs
 # miner.vc = Miner's validator consumer
 
 
-FailureContext: TypeAlias = dict[str, JsonValue] | None
+FailureContext: TypeAlias = dict[str, JsonValue]
 
 
 # executor <-> miner.ec <-> miner.vc <-> validator

--- a/executor/app/src/compute_horde_executor/executor/job_driver.py
+++ b/executor/app/src/compute_horde_executor/executor/job_driver.py
@@ -59,7 +59,6 @@ class JobDriver:
                 await self._execute()
 
             except JobError as e:
-                e.add_context({"stage": self.current_stage})
                 logger.error(str(e), exc_info=True)
                 await self.send_job_failed(e.message, e.reason, e.context)
 

--- a/executor/app/src/compute_horde_executor/executor/job_driver.py
+++ b/executor/app/src/compute_horde_executor/executor/job_driver.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 
 import packaging.version
+import sentry_sdk
+from compute_horde.job_errors import HordeError, JobError
 from compute_horde.protocol_consts import (
     HordeFailureReason,
     JobFailureReason,
@@ -19,9 +21,6 @@ from django.conf import settings
 
 from compute_horde_executor.executor.job_runner import BaseJobRunner
 from compute_horde_executor.executor.miner_client import (
-    ExecutionResult,
-    ExecutorError,
-    JobError,
     MinerClient,
 )
 from compute_horde_executor.executor.utils import get_machine_specs, temporary_process
@@ -60,28 +59,16 @@ class JobDriver:
                 await self._execute()
 
             except JobError as e:
-                logger.error(f"Job error: {e.reason}: {e.message}", exc_info=True)
-                await self.send_job_failed(e.message, e.reason, e.execution_result, e.context)
+                e.add_context({"stage": self.current_stage})
+                logger.error(str(e), exc_info=True)
+                await self.send_job_failed(e.message, e.reason, e.context)
 
-            except ExecutorError as e:
-                logger.error(f"Executor error: {e.reason}: {e.message}", exc_info=True)
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                e = HordeError.wrap_unhandled(e)
+                e.add_context({"stage": self.current_stage})
+                logger.exception(str(e), exc_info=True)
                 await self.send_horde_failed(e.message, e.reason, e.context)
-
-            except TimeoutError:
-                logger.error("Unhandled timeout")
-                await self.send_horde_failed(
-                    "Unhandled timeout",
-                    HordeFailureReason.UNHANDLED_TIMEOUT,
-                    context={"stage": self.current_stage},
-                )
-
-            except BaseException as e:
-                await self.send_horde_failed(
-                    "Executor failed with unexpected exception",
-                    HordeFailureReason.UNHANDLED_EXCEPTION,
-                    context={"stage": self.current_stage, "exception_type": type(e).__qualname__},
-                )
-                raise
 
             finally:
                 try:
@@ -97,7 +84,7 @@ class JobDriver:
                 initial_job_request = await self._startup_stage()
                 timing_details = initial_job_request.executor_timing
         except TimeoutError as e:
-            raise ExecutorError("Timed out waiting for initial job details from miner") from e
+            raise HordeError("Timed out waiting for initial job details from miner") from e
 
         if timing_details:
             # With timing details, re-initialize the deadline with leeway
@@ -107,7 +94,7 @@ class JobDriver:
             # For single-timeout, this is the full timeout for the whole job
             self._set_deadline(initial_job_request.timeout_seconds, "single-timeout mode")
         else:
-            raise ExecutorError(
+            raise HordeError(
                 "No timing received: either timeout_seconds or timing_details must be set"
             )
 
@@ -217,7 +204,7 @@ class JobDriver:
             return_code = docker_process.returncode
 
         if return_code != 0:
-            raise ExecutorError(
+            raise HordeError(
                 "CVE-2022-0492 check failed",
                 reason=HordeFailureReason.SECURITY_CHECK_FAILED,
                 context={
@@ -229,7 +216,7 @@ class JobDriver:
 
         expected_output = "Contained: cannot escape via CVE-2022-0492"
         if expected_output not in stdout.decode():
-            raise ExecutorError(
+            raise HordeError(
                 f'CVE-HordeFailureReason-0492 check failed: "{expected_output}" not in stdout.',
                 reason=HordeFailureReason.SECURITY_CHECK_FAILED,
                 context={
@@ -262,7 +249,7 @@ class JobDriver:
             return_code = docker_process.returncode
 
         if return_code != 0:
-            raise ExecutorError(
+            raise HordeError(
                 f"nvidia-container-toolkit check failed: exit code {return_code}",
                 reason=HordeFailureReason.SECURITY_CHECK_FAILED,
                 context={
@@ -274,7 +261,7 @@ class JobDriver:
 
         lines = stdout.decode().splitlines()
         if not lines:
-            raise ExecutorError(
+            raise HordeError(
                 "nvidia-container-toolkit check failed: no output from nvidia-container-toolkit",
                 reason=HordeFailureReason.SECURITY_CHECK_FAILED,
                 context={
@@ -289,7 +276,7 @@ class JobDriver:
             packaging.version.parse(version) >= NVIDIA_CONTAINER_TOOLKIT_MINIMUM_SAFE_VERSION
         )
         if not is_fixed_version:
-            raise ExecutorError(
+            raise HordeError(
                 f"Outdated NVIDIA Container Toolkit detected:"
                 f'{version}" not >= {NVIDIA_CONTAINER_TOOLKIT_MINIMUM_SAFE_VERSION}',
                 reason=HordeFailureReason.SECURITY_CHECK_FAILED,
@@ -307,23 +294,21 @@ class JobDriver:
             raise JobError(
                 "Job container timed out during execution",
                 reason=JobFailureReason.TIMEOUT,
-                execution_result=self.runner.execution_result,
             )
 
         if self.runner.execution_result.return_code != 0:
             raise JobError(
                 f"Job container exited with non-zero exit code: {self.runner.execution_result.return_code}",
                 reason=JobFailureReason.NONZERO_RETURN_CODE,
-                execution_result=self.runner.execution_result,
             )
 
     async def send_job_failed(
         self,
         message: str,
         reason: JobFailureReason,
-        execution_result: ExecutionResult | None,
         context: FailureContext | None = None,
     ):
+        execution_result = self.runner.execution_result
         await self.miner_client.send_job_failed(
             V0JobFailedRequest(
                 job_uuid=self.miner_client.job_uuid,

--- a/executor/app/src/compute_horde_executor/executor/miner_client.py
+++ b/executor/app/src/compute_horde_executor/executor/miner_client.py
@@ -4,10 +4,9 @@ from dataclasses import dataclass
 
 import pydantic
 from compute_horde.miner_client.base import AbstractMinerClient, UnsupportedMessageReceived
-from compute_horde.protocol_consts import HordeFailureReason, JobFailureReason
+from compute_horde.protocol_consts import JobFailureReason
 from compute_horde.protocol_messages import (
     ExecutorToMinerMessage,
-    FailureContext,
     GenericError,
     MinerToExecutorMessage,
     V0ExecutionDoneRequest,
@@ -41,35 +40,6 @@ class ExecutionResult:
 
     stdout: str
     stderr: str
-
-
-class JobError(Exception):
-    def __init__(
-        self,
-        message: str,
-        reason: JobFailureReason = JobFailureReason.UNKNOWN,
-        error_detail: str | None = None,
-        execution_result: ExecutionResult | None = None,
-        context: FailureContext | None = None,
-    ):
-        self.message = message
-        self.reason = reason
-        self.error_detail = error_detail
-        self.execution_result = execution_result
-        self.context = context
-
-
-class ExecutorError(Exception):
-    def __init__(
-        self,
-        message: str,
-        reason: HordeFailureReason = HordeFailureReason.GENERIC_ERROR,
-        context: FailureContext | None = None,
-    ) -> None:
-        super().__init__(f"Job failed {reason=}, {message=})")
-        self.reason = reason
-        self.message = message
-        self.context = context
 
 
 class MinerClient(AbstractMinerClient[MinerToExecutorMessage, ExecutorToMinerMessage]):

--- a/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
+++ b/executor/app/src/compute_horde_executor/executor/tests/integration/test_main_loop.py
@@ -1146,9 +1146,9 @@ def test_output_upload_failed(httpx_mock: HTTPXMock, tmp_path):
         },
         {
             "message_type": "V0JobFailedRequest",
-            "docker_process_exit_status": None,
-            "docker_process_stdout": None,
-            "docker_process_stderr": None,
+            "docker_process_exit_status": 0,
+            "docker_process_stdout": payload,
+            "docker_process_stderr": "",
             "message": "Upload failed",
             "reason": "upload_failed",
             "stage": "result_upload",

--- a/facilitator/app/src/project/core/migrations/0052_alter_jobstatus_status.py
+++ b/facilitator/app/src/project/core/migrations/0052_alter_jobstatus_status.py
@@ -36,7 +36,7 @@ def backwards(apps, schema_editor):
         "completed": 6,
         "streaming_ready": 7,
         "unknown": -2,
-        "horde_failed": -2
+        "horde_failed": -2,
     }
     for new, old in reverse_mapping.items():
         JobStatus.objects.filter(status=new).update(status=old)

--- a/precommit.sh
+++ b/precommit.sh
@@ -2,11 +2,18 @@
 
 set -e
 
-for projectdir in compute_horde compute_horde_sdk executor miner validator; do
+for projectdir in compute_horde compute_horde_sdk executor miner validator facilitator; do
   cd "${projectdir}"
   uv sync --all-groups --all-extras
   uv run ruff check --fix
   uv run ruff format
-  uv run nox -s type_check lint
+  uv run nox -s lint
+  cd ".."
+done
+
+# Type checking in facilitator is not a good idea
+for projectdir in compute_horde compute_horde_sdk executor miner validator ; do
+  cd "${projectdir}"
+  uv run nox -s type_check
   cd ".."
 done

--- a/validator/app/src/compute_horde_validator/validator/management/commands/debug_run_mock_streaming_job_to_miner.py
+++ b/validator/app/src/compute_horde_validator/validator/management/commands/debug_run_mock_streaming_job_to_miner.py
@@ -7,8 +7,8 @@ import uuid
 import requests
 import uvloop
 from asgiref.sync import async_to_sync
+from compute_horde.job_errors import HordeError
 from compute_horde.miner_client.organic import (
-    JobDriverError,
     OrganicJobDetails,
     OrganicMinerClient,
 )
@@ -63,7 +63,7 @@ async def run_streaming_job(options, wait_timeout: int = 300):
         try:
             await exit_stack.enter_async_context(client)
         except TransportConnectionError as exc:
-            raise JobDriverError(
+            raise HordeError(
                 f"Could not connect to trusted miner: {exc}",
                 HordeFailureReason.MINER_CONNECTION_FAILED,
             ) from exc
@@ -96,7 +96,7 @@ async def run_streaming_job(options, wait_timeout: int = 300):
                     timeout=min(job_timer.time_left(), wait_timeout),
                 )
             except TimeoutError as exc:
-                raise JobDriverError(
+                raise HordeError(
                     "Initial response timed out", HordeFailureReason.INITIAL_RESPONSE_TIMED_OUT
                 ) from exc
 
@@ -108,7 +108,7 @@ async def run_streaming_job(options, wait_timeout: int = 300):
                     timeout=min(job_timer.time_left(), wait_timeout),
                 )
             except TimeoutError as exc:
-                raise JobDriverError(
+                raise HordeError(
                     "Executor readiness timed out",
                     HordeFailureReason.EXECUTOR_READINESS_RESPONSE_TIMED_OUT,
                 ) from exc
@@ -134,7 +134,7 @@ async def run_streaming_job(options, wait_timeout: int = 300):
                     timeout=min(job_timer.time_left(), wait_timeout),
                 )
             except TimeoutError as exc:
-                raise JobDriverError(
+                raise HordeError(
                     "Streaming readiness timed out",
                     HordeFailureReason.STREAMING_JOB_READY_TIMED_OUT,
                 ) from exc
@@ -182,7 +182,7 @@ async def run_streaming_job(options, wait_timeout: int = 300):
                 logger.info(f"Job finished: {final_response}")
 
             except TimeoutError as exc:
-                raise JobDriverError(
+                raise HordeError(
                     "Final response timed out", HordeFailureReason.FINAL_RESPONSE_TIMED_OUT
                 ) from exc
         except Exception:

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import bittensor_wallet
 import httpx
 import pydantic
+import sentry_sdk
 import tenacity
 import websockets
 from channels.layers import get_channel_layer
@@ -27,6 +28,7 @@ from compute_horde.fv_protocol.validator_requests import (
     V0Heartbeat,
     V0MachineSpecsUpdate,
 )
+from compute_horde.job_errors import HordeError
 from compute_horde.protocol_consts import (
     HordeFailureReason,
     JobFailureReason,
@@ -302,9 +304,11 @@ class FacilitatorClient:
                         return
                 except pydantic.ValidationError as exc:
                     logger.warning("Received malformed job status update: %s", exc)
-        except Exception:
-            logger.exception("Error in job status update listener", exc_info=True)
+        except asyncio.CancelledError:
             raise
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception("Error in job status update listener", exc_info=True)
         finally:
             logger.debug(f"Finished listening for job status updates for job {job_uuid}")
 
@@ -419,6 +423,8 @@ class FacilitatorClient:
                 context={"exception_type": type(e).__qualname__},
             )
         except Exception as e:
+            sentry_sdk.capture_exception(e)
+            e = HordeError.wrap_unhandled(e)
             await self.send_horde_failed(
                 job_uuid=job_request.uuid,
                 message="Uncaught exception during handling of job",

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
@@ -304,9 +304,8 @@ class FacilitatorClient:
                         return
                 except pydantic.ValidationError as exc:
                     logger.warning("Received malformed job status update: %s", exc)
-        except asyncio.CancelledError:
-            raise
         except Exception as e:
+            # Nothing that gets thrown here is expected.
             sentry_sdk.capture_exception(e)
             logger.exception("Error in job status update listener", exc_info=True)
         finally:

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
@@ -307,7 +307,7 @@ class FacilitatorClient:
         except Exception as e:
             # Nothing that gets thrown here is expected.
             sentry_sdk.capture_exception(e)
-            logger.exception("Error in job status update listener", exc_info=True)
+            logger.warning("Error in job status update listener", exc_info=True)
         finally:
             logger.debug(f"Finished listening for job status updates for job {job_uuid}")
 

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/facilitator_client.py
@@ -426,10 +426,10 @@ class FacilitatorClient:
             e = HordeError.wrap_unhandled(e)
             await self.send_horde_failed(
                 job_uuid=job_request.uuid,
-                message="Uncaught exception during handling of job",
                 reported_by=JobParticipantType.VALIDATOR,
-                reason=HordeFailureReason.UNHANDLED_EXCEPTION,
-                context={"exception_type": type(e).__qualname__},
+                message=e.message,
+                reason=e.reason,
+                context=e.context,
             )
 
     async def _process_job_request(self, job_request: OrganicJobRequest) -> None:

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
@@ -437,8 +437,8 @@ async def drive_organic_job(
         await notify_callback(status_update)
 
     except Exception as e:
-        e = HordeError.wrap_unhandled(e)
         sentry_sdk.capture_exception(e)
+        e = HordeError.wrap_unhandled(e)
         comment = str(e)
         logger.warning(comment)
         job.status = OrganicJob.Status.FAILED

--- a/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
+++ b/validator/app/src/compute_horde_validator/validator/organic_jobs/miner_driver.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Awaitable, Callable
 from functools import partial
 
+import sentry_sdk
 from channels.layers import get_channel_layer
 from compute_horde.fv_protocol.facilitator_requests import OrganicJobRequest, V2JobRequest
 from compute_horde.fv_protocol.validator_requests import (
@@ -14,8 +15,8 @@ from compute_horde.fv_protocol.validator_requests import (
     JobStatusUpdate,
     StreamingServerDetails,
 )
+from compute_horde.job_errors import HordeError
 from compute_horde.miner_client.organic import (
-    JobDriverError,
     MinerRejectedJob,
     MinerReportedHordeFailed,
     MinerReportedJobFailed,
@@ -130,7 +131,7 @@ def status_update_from_horde_failure(
     )
 
 
-def status_update_from_organic_job_error(job: OrganicJob, error: JobDriverError) -> JobStatusUpdate:
+def status_update_from_organic_job_error(job: OrganicJob, error: HordeError) -> JobStatusUpdate:
     metadata = JobStatusMetadata(
         horde_failure_details=HordeFailureDetails(
             reported_by=JobParticipantType.VALIDATOR,
@@ -435,27 +436,21 @@ async def drive_organic_job(
         status_update = status_update_from_horde_failure(job, failure)
         await notify_callback(status_update)
 
-    except JobDriverError as exc:
-        comment = exc.message
+    except Exception as e:
+        e = HordeError.wrap_unhandled(e)
+        sentry_sdk.capture_exception(e)
+        comment = str(e)
+        logger.warning(comment)
         job.status = OrganicJob.Status.FAILED
         job.comment = comment
         await job.asave()
-        logger.warning(comment)
+
         event_subtype = _horde_event_subtype_map.get(
-            exc.reason, SystemEvent.EventSubType.GENERIC_ERROR
+            e.reason, SystemEvent.EventSubType.GENERIC_ERROR
         )
         await save_event(subtype=event_subtype, long_description=comment)
-        status_update = status_update_from_organic_job_error(job, exc)
-        await notify_callback(status_update)
 
-    except Exception as exc:
-        comment = f"Unexpected error while handling organic job: {type(exc).__qualname__} ({exc})"
-        job.status = OrganicJob.Status.FAILED
-        job.comment = comment
-        await job.asave()
-        logger.exception(comment, exc_info=True)
-        await save_event(subtype=SystemEvent.EventSubType.GENERIC_ERROR, long_description=comment)
-        status_update = status_update_from_generic_exception(job, exc)
+        status_update = status_update_from_organic_job_error(job, e)
         await notify_callback(status_update)
 
     return False


### PR DESCRIPTION
- Pulled out the 3 main error classes to compute_horde. This way we can throw these during job execution (almost?) anywhere and they should be handled correctly.
- (still, throwing an error where it is not appropriate, e.g. a rejection in an executor JobDriver, will be treated as a generic horde failure)
- Added a helper for wrapping unhandled exceptions into a HordeError, so that they are a bit more consistent
- Explicitly logging exceptions to sentry where they would've been only wrapped and propagated. They are potentially interesting to log.