### PR TITLE
Fix validator database deadlock on allowance eviction task

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/allowance/tasks.py
+++ b/validator/app/src/compute_horde_validator/validator/allowance/tasks.py
@@ -80,7 +80,7 @@ def sync_manifests():
 
 @app.task()
 def evict_old_data():
-    with transaction.atomic(using=settings.DEFAULT_DB_ALIAS):
+    with transaction.atomic():
         try:
             get_advisory_lock(LockType.ALLOWANCE_EVICTING)
         except Locked:


### PR DESCRIPTION
The lock was being acquired on a different connection than the rest of the task. That connection was auto-committing, so the lock was released immediately.