### PR TITLE
Use correct stake in allowance calculation

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/allowance/types.py
+++ b/validator/app/src/compute_horde_validator/validator/allowance/types.py
@@ -18,6 +18,12 @@ class Neuron(pydantic.BaseModel):
     coldkey: ss58_address
 
 
+class ValidatorModel(pydantic.BaseModel):
+    uid: int
+    hotkey: ss58_address
+    effective_stake: float
+
+
 class AllowanceException(Exception):
     pass
 

--- a/validator/app/src/compute_horde_validator/validator/allowance/utils/supertensor_django_cache.py
+++ b/validator/app/src/compute_horde_validator/validator/allowance/utils/supertensor_django_cache.py
@@ -5,6 +5,7 @@ import pickle
 import turbobt
 from django.core.cache import cache
 
+from compute_horde_validator.validator.allowance.types import ValidatorModel
 from compute_horde_validator.validator.allowance.utils.supertensor import BaseCache
 
 logger = logging.getLogger(__name__)
@@ -59,4 +60,44 @@ class DjangoCache(BaseCache):
             return unpickled
         except Exception:
             logger.error("Error deserializing block timestamp:", exc_info=True)
+            return None
+
+    def put_subnet_state(self, block_number: int, state: turbobt.subnet.SubnetState):
+        key = self._get_key("subnet_state", block_number)
+        try:
+            pickled_data = pickle.dumps(state)
+            cache.set(key, pickled_data, self.cache_timeout)
+        except Exception:
+            logger.error("Error serializing subnet state:", exc_info=True)
+
+    def get_subnet_state(self, block_number: int) -> turbobt.subnet.SubnetState | None:
+        key = self._get_key("subnet_state", block_number)
+        pickled_data = cache.get(key)
+        if pickled_data is None:
+            return None
+        try:
+            unpickled: turbobt.subnet.SubnetState = pickle.loads(pickled_data)
+            return unpickled
+        except Exception:
+            logger.error("Error deserializing subnet state:", exc_info=True)
+            return None
+
+    def put_validators(self, block_number: int, validators: list[ValidatorModel]):
+        key = self._get_key("validators", block_number)
+        try:
+            pickled_data = pickle.dumps(validators)
+            cache.set(key, pickled_data, self.cache_timeout)
+        except Exception:
+            logger.error("Error serializing validators:", exc_info=True)
+
+    def get_validators(self, block_number: int) -> list[ValidatorModel] | None:
+        key = self._get_key("validators", block_number)
+        pickled_data = cache.get(key)
+        if pickled_data is None:
+            return None
+        try:
+            unpickled: list[ValidatorModel] = pickle.loads(pickled_data)
+            return unpickled
+        except Exception:
+            logger.error("Error deserializing validators:", exc_info=True)
             return None

--- a/validator/app/src/compute_horde_validator/validator/routing/tests/test_job_routing_incident.py
+++ b/validator/app/src/compute_horde_validator/validator/routing/tests/test_job_routing_incident.py
@@ -19,6 +19,7 @@ from django.db.models import Sum as DjangoSum
 
 from compute_horde_validator.validator.allowance.default import allowance
 from compute_horde_validator.validator.allowance.types import Miner as AllowanceMiner
+from compute_horde_validator.validator.allowance.types import ValidatorModel
 from compute_horde_validator.validator.allowance.utils import blocks, manifests
 from compute_horde_validator.validator.allowance.utils import supertensor as st_mod
 from compute_horde_validator.validator.models import Miner, MinerIncident, OrganicJob
@@ -207,8 +208,23 @@ async def reliability_env(
             ),
             raising=False,
         )
-        monkeypatch.setattr(_st, "list_validators", lambda bn: [neurons[0]], raising=False)
+        monkeypatch.setattr(
+            _st,
+            "list_validators",
+            lambda bn: [
+                ValidatorModel(
+                    uid=neurons[0].uid, hotkey=neurons[0].hotkey, effective_stake=10000.0
+                )
+            ],
+            raising=False,
+        )
         monkeypatch.setattr(_st, "get_current_block", lambda: base_block, raising=False)
+        monkeypatch.setattr(
+            _st,
+            "get_subnet_state",
+            lambda bn: {"total_stake": [10000.0] + [1000.0] * len(miners)},
+            raising=False,
+        )
 
     def _advance_current_block(_st, bn):
         monkeypatch.setattr(_st, "get_current_block", lambda _bn=bn: _bn, raising=False)


### PR DESCRIPTION
Instead of using the neuron’s `stake` field in the allowance calculation, use the effective stake retrieved from the global state.