### PR TITLE
Improve collateral tests

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/collateral/tests/conftest.py
+++ b/validator/app/src/compute_horde_validator/validator/collateral/tests/conftest.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from compute_horde_validator.validator.collateral import default as collateral_default
+
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "compute_horde_validator.validator.tests.settings",
+)
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _reset_collateral_cache() -> None:
+    collateral_default._cached_contract_address = None

--- a/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/contexts.py
+++ b/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/contexts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+from unittest.mock import Mock
+
+from web3 import Web3
+
+from compute_horde_validator.validator.collateral import tasks as collateral_tasks
+from compute_horde_validator.validator.collateral.tasks import CollateralTaskDependencies
+
+from .env import CollateralTestEnvironment
+
+__all__ = [
+    "CollateralTestEnvironment",
+    "CollateralTaskHarness",
+]
+
+
+@dataclass
+class CollateralTaskHarness:
+    env: CollateralTestEnvironment
+    neurons: list[Any]
+    block_number: int
+    block_hash: str
+    associations: dict[int, str]
+
+    def run(self) -> None:
+        deps = CollateralTaskDependencies(
+            fetch_metagraph=self._fetch_metagraph,
+            fetch_evm_key_associations=self._fetch_associations,
+            web3=lambda _network: cast(Web3, self.env.web3),
+            collateral=lambda: self.env.collateral,
+            system_events=lambda: self.env.system_events,
+        )
+        collateral_tasks.sync_collaterals.run(deps=deps)
+
+    def _fetch_metagraph(self, _bittensor: Any) -> tuple[list[Any], Any, Any]:
+        block = Mock(number=self.block_number, hash=self.block_hash)
+        subnet_state = Mock()
+        return self.neurons, subnet_state, block
+
+    def _fetch_associations(
+        self, _subtensor: Any, netuid: int, block_hash: str | None
+    ) -> dict[int, str]:
+        self.env.fetch_log.append({"netuid": netuid, "block_hash": block_hash})
+        return self.associations

--- a/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/env.py
+++ b/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/env.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import Mock, patch
+
+from hexbytes import HexBytes
+
+from compute_horde_validator.validator.collateral import default as collateral_default
+from compute_horde_validator.validator.collateral.default import Collateral
+
+from .stubs import (
+    HttpStub,
+    SystemEventRecorder,
+    Web3Call,
+    Web3Stub,
+    _BittensorWrapper,
+    _ShieldedBittensorFactory,
+)
+
+
+class CollateralTestEnvironment:
+    def __init__(
+        self,
+        *,
+        slash_amount: int = 1_000,
+        contract_address: str | None = "0xcontract",
+        private_key: str | None = "0xprivate",
+        http_bytes: bytes = b"",
+        http_ok: bool = True,
+        receipt: dict[str, Any] | None = None,
+        collateral_values: dict[str, int | Exception] | None = None,
+    ) -> None:
+        self.slash_amount = slash_amount
+        self.contract_address = contract_address
+        self.private_key = private_key
+        self.http_bytes = http_bytes
+        self.http_ok = http_ok
+        self.receipt_data = receipt or {"status": 1}
+        self.collateral_values = {
+            address.upper(): value for address, value in (collateral_values or {}).items()
+        }
+        self.requested_urls: list[str] = []
+        self.transaction_call: tuple[tuple[Any, ...], dict[str, Any]] | None = None
+        self.web3_calls: list[Web3Call] = []
+        self.fetch_log: list[dict[str, Any]] = []
+        self.system_events = SystemEventRecorder()
+        self.contract_log: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> CollateralTestEnvironment:
+        self._stack = ExitStack()
+        self.web3 = Web3Stub(self)
+        self.http = HttpStub(self)
+        self._stack.enter_context(
+            patch(
+                "compute_horde_validator.validator.collateral.default.requests.get",
+                self.http,
+            )
+        )
+        self._stack.enter_context(
+            patch(
+                "compute_horde_validator.validator.collateral.default.get_web3_connection",
+                return_value=self.web3,
+            )
+        )
+        self._stack.enter_context(
+            patch.object(collateral_default, "_cached_contract_address", None)
+        )
+        self._config = Mock()
+        self._config.DYNAMIC_COLLATERAL_SLASH_AMOUNT_WEI = self.slash_amount
+        self._stack.enter_context(patch.object(collateral_default, "config", self._config))
+        self._stack.enter_context(
+            patch(
+                "compute_horde_validator.validator.collateral.default.settings.BITTENSOR_WALLET",
+                return_value=self._mock_wallet(),
+            )
+        )
+        self._stack.enter_context(
+            patch(
+                "compute_horde_validator.validator.collateral.default.Account.from_key",
+                side_effect=self._account_from_key,
+            )
+        )
+        bittensor_wrapper = _BittensorWrapper(self)
+        self._stack.enter_context(
+            patch(
+                "compute_horde_validator.validator.collateral.default.turbobt.Bittensor",
+                new=bittensor_wrapper,
+            )
+        )
+        shielded_wrapper = _ShieldedBittensorFactory(self)
+        self._stack.enter_context(
+            patch(
+                "compute_horde_validator.validator.clean_me_up.ShieldedBittensor",
+                new=shielded_wrapper,
+            )
+        )
+        self.collateral = Collateral()
+        self._stack.enter_context(
+            patch.object(
+                self.collateral,
+                "_get_private_key",
+                side_effect=lambda: self.private_key,
+            )
+        )
+        self._stack.enter_context(
+            patch.object(
+                self.collateral,
+                "_build_and_send_transaction",
+                side_effect=self._record_transaction,
+            )
+        )
+        self._stack.enter_context(
+            patch.object(
+                self.collateral,
+                "_get_collateral_abi",
+                return_value=[{"name": "slashCollateral"}],
+            )
+        )
+        return self
+
+    def __exit__(self, exc_type: Any, exc: BaseException | None, tb: Any) -> None:
+        self._stack.__exit__(exc_type, exc, tb)
+
+    async def __aenter__(self) -> CollateralTestEnvironment:
+        self.__enter__()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: BaseException | None, tb: Any) -> None:
+        self.__exit__(exc_type, exc, tb)
+
+    def set_http_response(self, content: bytes, *, ok: bool = True) -> None:
+        self.http_bytes = content
+        self.http_ok = ok
+
+    def set_receipt(self, receipt: dict[str, Any]) -> None:
+        self.receipt_data = receipt
+
+    def set_slash_amount(self, amount: int) -> None:
+        self.slash_amount = amount
+        self._config.DYNAMIC_COLLATERAL_SLASH_AMOUNT_WEI = amount
+
+    def _record_transaction(
+        self,
+        _web3: Any,
+        function: Any,
+        _account: Any,
+        gas_limit: int,
+        *,
+        value: int = 0,
+    ) -> HexBytes:
+        self.transaction_call = (function.args, {"gas_limit": gas_limit, "value": value})
+        return HexBytes("0xdead")
+
+    def _account_from_key(self, key: str | None) -> Mock:
+        if key != self.private_key:
+            raise AssertionError("Unexpected private key provided")
+        return Mock(address="0xaccount", key=b"\x00" * 32)
+
+    def _mock_wallet(self) -> Any:
+        wallet = Mock()
+        wallet.hotkey = Mock()
+        wallet.hotkey.ss58_address = "stub-ss58"
+        return wallet
+
+
+__all__ = [
+    "CollateralTestEnvironment",
+    "Web3Call",
+]

--- a/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/setup_helpers.py
+++ b/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/setup_helpers.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from decimal import Decimal
+from typing import Any
+
+from asgiref.sync import sync_to_async
+
+from compute_horde_validator.validator.models import Miner
+
+
+@contextmanager
+def setup_collateral(
+    *,
+    miners: list[Miner],
+    uids: dict[str, int] | None = None,
+    evm_addresses: dict[str, str | None] | None = None,
+    collaterals_wei: dict[str, int] | None = None,
+) -> Iterator[list[Miner]]:
+    previous: dict[int, dict[str, Any]] = {}
+    hotkey_to_miner: dict[str, Miner] = {m.hotkey: m for m in miners}
+
+    def _collect_updates(hotkey: str) -> dict[str, Any]:
+        updates: dict[str, Any] = {}
+        if uids and hotkey in uids:
+            updates["uid"] = uids[hotkey]
+        if evm_addresses and hotkey in evm_addresses:
+            updates["evm_address"] = evm_addresses[hotkey]
+        if collaterals_wei and hotkey in collaterals_wei:
+            updates["collateral_wei"] = Decimal(collaterals_wei[hotkey])
+        return updates
+
+    try:
+        for hotkey, miner in hotkey_to_miner.items():
+            updates = _collect_updates(hotkey)
+            if not updates:
+                continue
+            previous[miner.pk] = {
+                "uid": miner.uid,
+                "evm_address": miner.evm_address,
+                "collateral_wei": miner.collateral_wei,
+            }
+            Miner.objects.filter(pk=miner.pk).update(**updates)
+            miner.refresh_from_db()
+        yield miners
+    finally:
+        if previous:
+            for miner in miners:
+                if miner.pk not in previous:
+                    continue
+                Miner.objects.filter(pk=miner.pk).update(**previous[miner.pk])
+                miner.refresh_from_db()
+
+
+@asynccontextmanager
+async def async_setup_collateral(
+    *,
+    miners: list[Miner],
+    uids: dict[str, int] | None = None,
+    evm_addresses: dict[str, str | None] | None = None,
+    collaterals_wei: dict[str, int] | None = None,
+) -> AsyncIterator[list[Miner]]:
+    ctx = setup_collateral(
+        miners=miners,
+        uids=uids,
+        evm_addresses=evm_addresses,
+        collaterals_wei=collaterals_wei,
+    )
+    await sync_to_async(ctx.__enter__, thread_sensitive=True)()
+    try:
+        yield miners
+    finally:
+        await sync_to_async(ctx.__exit__, thread_sensitive=True)(None, None, None)
+
+
+__all__ = [
+    "setup_collateral",
+    "async_setup_collateral",
+]

--- a/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/stubs.py
+++ b/validator/app/src/compute_horde_validator/validator/collateral/tests/helpers/stubs.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock
+
+if TYPE_CHECKING:
+    from .env import CollateralTestEnvironment
+
+
+@dataclass
+class Web3Call:
+    miner_address: str
+    block_identifier: int | None
+
+
+class HttpStub:
+    def __init__(self, facade: CollateralTestEnvironment) -> None:
+        self._facade = facade
+
+    def __call__(self, url: str, *, timeout: int | float | None = None) -> Any:
+        self._facade.requested_urls.append(url)
+
+        class _Response:
+            def __init__(self, data: bytes, ok: bool) -> None:
+                self.content = data
+                self._ok = ok
+
+            def raise_for_status(self) -> None:
+                if not self._ok:
+                    raise RuntimeError("HTTP error")
+
+        return _Response(self._facade.http_bytes, self._facade.http_ok)
+
+
+class Web3Stub:
+    def __init__(self, facade: CollateralTestEnvironment) -> None:
+        self._facade = facade
+        self.eth = Mock()
+        self.eth.contract = self._contract
+        self.eth.wait_for_transaction_receipt = self._wait_for_receipt
+
+    def to_checksum_address(self, value: str) -> str:
+        return value.upper()
+
+    def _contract(self, *, address: str, abi: Any) -> Any:
+        checksum = self.to_checksum_address(address)
+        self._facade.contract_log.append((checksum, abi))
+
+        def collaterals(miner_address: str) -> Any:
+            miner_checksum = self.to_checksum_address(miner_address)
+
+            def call(*, block_identifier: int | None = None) -> int:
+                self._facade.web3_calls.append(
+                    Web3Call(miner_address=miner_checksum, block_identifier=block_identifier)
+                )
+                value = self._facade.collateral_values.get(miner_checksum, 0)
+                if isinstance(value, Exception):
+                    raise value
+                assert isinstance(value, int)
+                return value
+
+            obj = Mock()
+            obj.call = call
+            return obj
+
+        def slash_collateral(
+            miner_address: str,
+            amount_wei: int,
+            url: str,
+            checksum: bytes,
+        ) -> Any:
+            tx = Mock()
+            tx.args = (miner_address, amount_wei, url, checksum)
+            return tx
+
+        functions = Mock()
+        functions.collaterals = collaterals
+        functions.slashCollateral = slash_collateral
+
+        contract = Mock()
+        contract.functions = functions
+        return contract
+
+    def _wait_for_receipt(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return self._facade.receipt_data
+
+
+class SystemEventRecorder:
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def create(self, **data: Any) -> None:
+        self.records.append(data)
+
+
+class BittensorStub:
+    def __init__(self, facade: CollateralTestEnvironment) -> None:
+        self._facade = facade
+        self.subtensor = Mock()
+
+    async def __aenter__(self) -> BittensorStub:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: BaseException | None, tb: Any) -> None:
+        return None
+
+    def subnet(self, _netuid: int) -> Any:
+        facade = self._facade
+
+        subnet = Mock()
+        subnet.commitments = Mock()
+        subnet.commitments.get = _CommitmentGetter(facade).get
+        return subnet
+
+
+class _CommitmentGetter:
+    def __init__(self, facade: CollateralTestEnvironment) -> None:
+        self._facade = facade
+
+    async def get(self, _hotkey: str) -> str | None:
+        if self._facade.contract_address is None:
+            return None
+        return json.dumps({"contract": {"address": self._facade.contract_address}})
+
+
+class _BittensorWrapper:
+    def __init__(self, facade: CollateralTestEnvironment) -> None:
+        self._facade = facade
+
+    def __call__(self, *_args: Any, **_kwargs: Any) -> BittensorStub:
+        return BittensorStub(self._facade)
+
+    def subnet(self, instance: BittensorStub, netuid: int) -> Any:
+        return instance.subnet(netuid)
+
+
+class _ShieldedBittensorFactory:
+    def __init__(self, facade: Any) -> None:
+        self._facade = facade
+
+    def __call__(
+        self,
+        _network: str,
+        *,
+        ddos_shield_netuid: int,
+        **_kwargs: Any,
+    ) -> _ShieldedBittensorInstance:
+        return _ShieldedBittensorInstance(self._facade, ddos_shield_netuid)
+
+
+class _ShieldedBittensorInstance:
+    def __init__(self, facade: CollateralTestEnvironment, netuid: int) -> None:
+        self._facade = facade
+        self.ddos_shield = Mock()
+        self.ddos_shield.netuid = netuid
+
+    async def __aenter__(self) -> BittensorStub:
+        return BittensorStub(self._facade)
+
+    async def __aexit__(self, exc_type: Any, exc: BaseException | None, tb: Any) -> None:
+        return None
+
+
+__all__ = [
+    "Web3Call",
+    "HttpStub",
+    "Web3Stub",
+    "SystemEventRecorder",
+    "BittensorStub",
+    "_BittensorWrapper",
+    "_ShieldedBittensorFactory",
+]


### PR DESCRIPTION
Refactor collateral tests to use use clean, reusable testing setup with clear responsibilities and minimal boilerplate.

- `CollateralTestEnvironment` - sets up stubs for Web3, HTTP, Bittensor and config.
- `CollateralTaskHarness` - wires up the test environment for `sync_collaterals` task tests.
- `setup_collateral` and `async_setup_collateral` - DB helpers to set `uid`, `evm_address` and `collateral_wei` on Miner.
- `sync_collaterals` accepts an optional `CollateralTaskDependencies` object, enabling injection of dependencies.