### PR TITLE
fix: skip synthetic jobs during scoring

### DIFF
--- a/validator/app/src/compute_horde_validator/validator/receipts/README.md
+++ b/validator/app/src/compute_horde_validator/validator/receipts/README.md
@@ -63,6 +63,7 @@ rows: list[JobSpendingInfo] = await receipts().get_finished_jobs_for_block_range
     start_block: int,
     end_block: int,
     executor_class: ExecutorClass,
+    organic_only=False,
 )
 """Each row is a JobSpendingInfo model with fields:
 - job_uuid: str

--- a/validator/app/src/compute_horde_validator/validator/receipts/base.py
+++ b/validator/app/src/compute_horde_validator/validator/receipts/base.py
@@ -103,11 +103,16 @@ class ReceiptsBase(ABC):
 
     @abstractmethod
     def get_finished_jobs_for_block_range(
-        self, start_block: int, end_block: int, executor_class: ExecutorClass
+        self,
+        start_block: int,
+        end_block: int,
+        executor_class: ExecutorClass,
+        organic_only: bool = False,
     ) -> list[JobSpendingInfo]:
         """
         Returns tuples for jobs whose finish (receipt) timestamp falls within the
-        given block range [start_block, end_block), filtered by executor class.
+        given block range [start_block, end_block), filtered by executor class and
+        optionally whether the job was organic or not.
         """
         pass
 

--- a/validator/app/src/compute_horde_validator/validator/receipts/default.py
+++ b/validator/app/src/compute_horde_validator/validator/receipts/default.py
@@ -214,7 +214,7 @@ class Receipts(ReceiptsBase):
         return await JobStartedReceipt.objects.aget(job_uuid=job_uuid)
 
     def get_finished_jobs_for_block_range(
-        self, start_block: int, end_block: int, executor_class: ExecutorClass
+        self, start_block: int, end_block: int, executor_class: ExecutorClass, organic_only=False
     ) -> list[JobSpendingInfo]:
         """
         Returns the alleged job spendings as reported by miners via receipt transfer.
@@ -240,6 +240,9 @@ class Receipts(ReceiptsBase):
         starts = JobStartedReceipt.objects.filter(
             job_uuid=OuterRef("job_uuid"), executor_class=str(executor_class)
         )
+        # Filter for organic jobs if requested - also present on the job started receipt
+        if organic_only:
+            starts = starts.filter(is_organic=True)
         finished_qs = finished_qs.filter(Exists(starts))
 
         # TODO(new scoring): this could be inefficient

--- a/validator/app/src/compute_horde_validator/validator/scoring/calculations.py
+++ b/validator/app/src/compute_horde_validator/validator/scoring/calculations.py
@@ -59,8 +59,9 @@ def calculate_allowance_paid_job_scores(
 
     for executor_class in ExecutorClass:
         # Find out what jobs finished within the time and get the associated spending info
+        # We only care about organic jobs here
         job_spendings = receipts().get_finished_jobs_for_block_range(
-            start_block, end_block, executor_class
+            start_block, end_block, executor_class, organic_only=True
         )
 
         logger.info(

--- a/validator/app/src/compute_horde_validator/validator/scoring/tests/test_paid_job_scores.py
+++ b/validator/app/src/compute_horde_validator/validator/scoring/tests/test_paid_job_scores.py
@@ -234,7 +234,7 @@ def test_paid_job_scores(job_spendings, expected_scores):
     check if for simple and edge cases the scoring setup validates the spendings as expected.
     """
 
-    def finished_jobs(_, __, executor_class):
+    def finished_jobs(_, __, executor_class, organic_only):
         return job_spendings if executor_class == ExecutorClass.always_on__gpu_24gb else []
 
     with patch(


### PR DESCRIPTION
Gets rid of noise in the scoring metrics.
It's safer and easier to let them run for a while, just skip them during scoring.