### PR TITLE
ci: add GH action for commit linting

### DIFF
--- a/.github/workflows/commit_linting.yaml
+++ b/.github/workflows/commit_linting.yaml
@@ -1,0 +1,110 @@
+name: Commit Message Linting
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+env:
+  PYTHON_DEFAULT_VERSION: "3.11"
+
+jobs:
+  commit_message_lint:
+    name: Commit message lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ env.PYTHON_DEFAULT_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv tool install gitlint-core
+
+      - name: Determine commit range
+        id: range
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          echo "base=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "range=$BASE_SHA..$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Run gitlint
+        id: gitlint
+        shell: bash
+        continue-on-error: true
+        run: |
+          set +e
+          RANGE="${{ steps.range.outputs.range }}"
+          echo "Linting commit range: $RANGE" | tee gitlint_output.txt
+          echo "gitlint --commits \"$RANGE\"" >> gitlint_output.txt 
+          gitlint --commits "$RANGE" >> gitlint_output.txt 2>&1
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "Gitlint found issues in the commit messages." >> gitlint_output.txt
+          else
+            echo "No issues found by gitlint." >> gitlint_output.txt
+          fi
+          tail -n +1 gitlint_output.txt
+
+      - name: Build PR comment body
+        shell: bash
+        run: |
+          {
+            echo "### Commit message lint report"
+            echo "\`gitlint --commits ${{ steps.range.outputs.range }}\`" 
+            echo
+            echo
+            if [ "${{ steps.gitlint.outputs.exit_code }}" = "0" ]; then
+              echo "Status: ✅ No issues found."
+            else
+              echo "Status: ❌ Issues found."
+              echo
+              echo "gitlint output:"
+              echo
+              echo '```'
+              cat gitlint_output.txt
+              echo '```'
+              echo 
+              echo "Fix by amending/rewording your commits (e.g., using \`git rebase -i\` and \`git commit --amend\`)."
+            fi
+          } > lint_report.md
+
+      - name: Post or update sticky PR comment
+        id: comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: commit_message_lint_report
+          path: lint_report.md
+          recreate: true
+
+      - name: Debug info about sticky comments
+        run: |
+          echo "Previous comment id: ${{ steps.comment.outputs.previous_comment_id }}"
+          echo "Created comment id: ${{ steps.comment.outputs.created_comment_id }}"
+
+      - name: Write job summary
+        shell: bash
+        run: |
+          cat lint_report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail job when commit messages violate rules
+        if: ${{ steps.gitlint.outputs.exit_code != '0' }}
+        shell: bash
+        run: exit 1

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,147 @@
+# Edit this file as you like.
+#
+# All these sections are optional. Each section with the exception of [general] represents
+# one rule and each key in it is an option for that specific rule.
+#
+# Rules and sections can be referenced by their full name or by id. For example
+# section "[body-max-line-length]" could also be written as "[B1]". Full section names are
+# used in here for clarity.
+#
+# [general]
+# Ignore certain rules, this example uses both full name and id
+# ignore=title-trailing-punctuation, T3
+
+# verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
+# verbosity = 2
+
+# By default gitlint will ignore merge, revert, fixup, fixup=amend, and squash commits.
+# ignore-merge-commits=true
+# ignore-revert-commits=true
+# ignore-fixup-commits=true
+# ignore-fixup-amend-commits=true
+# ignore-squash-commits=true
+
+# Ignore any data sent to gitlint via stdin
+# ignore-stdin=true
+
+# Fetch additional meta-data from the local repository when manually passing a
+# commit message to gitlint via stdin or --commit-msg. Disabled by default.
+# staged=true
+
+# Hard fail when the target commit range is empty. Note that gitlint will
+# already fail by default on invalid commit ranges. This option is specifically
+# to tell gitlint to fail on *valid but empty* commit ranges.
+# Disabled by default.
+# fail-without-commits=true
+
+# Whether to use Python `search` instead of `match` semantics in rules that use
+# regexes. Context: https://github.com/jorisroovers/gitlint/issues/254
+# Disabled by default, but will be enabled by default in the future.
+# regex-style-search=true
+
+# Enable debug mode (prints more output). Disabled by default.
+# debug=true
+
+# Enable community contributed rules
+# See http://jorisroovers.github.io/gitlint/contrib_rules for details
+# contrib=contrib-title-conventional-commits,CC1
+
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+# extra-path=examples/
+
+# This is an example of how to configure the "title-max-length" rule and
+# set the line-length it enforces to 50
+# [title-max-length]
+# line-length=50
+
+# Conversely, you can also enforce minimal length of a title with the
+# "title-min-length" rule:
+# [title-min-length]
+# min-length=5
+
+# [title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will.
+# words=wip
+
+# [title-match-regex]
+# python-style regex that the commit-msg title must match
+# Note that the regex can contradict with other rules if not used correctly
+# (e.g. title-must-not-contain-word).
+# regex=^US[0-9]*
+
+# [body-max-line-length]
+# line-length=72
+
+# [body-min-length]
+# min-length=5
+
+# [body-is-missing]
+# Whether to ignore this rule on merge commits (which typically only have a title)
+# default = True
+# ignore-merge-commits=false
+
+# [body-changed-file-mention]
+# List of files that need to be explicitly mentioned in the body when they are changed
+# This is useful for when developers often erroneously edit certain files or git submodules.
+# By specifying this rule, developers can only change the file when they explicitly reference
+# it in the commit message.
+# files=gitlint-core/gitlint/rules.py,README.md
+
+# [body-match-regex]
+# python-style regex that the commit-msg body must match.
+# E.g. body must end in My-Commit-Tag: foo
+# regex=My-Commit-Tag: foo$
+
+# [author-valid-email]
+# python-style regex that the commit author email address must match.
+# For example, use the following regex if you only want to allow email addresses from foo.com
+# regex=[^@]+@foo.com
+
+# [ignore-by-title]
+# Ignore certain rules for commits of which the title matches a regex
+# E.g. Match commit titles that start with "Release"
+# regex=^Release(.*)
+
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+# ignore=T1,body-min-length
+
+# [ignore-by-body]
+# Ignore certain rules for commits of which the body has a line that matches a regex
+# E.g. Match bodies that have a line that that contain "release"
+# regex=(.*)release(.*)
+#
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+# ignore=T1,body-min-length
+
+# [ignore-body-lines]
+# Ignore certain lines in a commit body that match a regex.
+# E.g. Ignore all lines that start with 'Co-Authored-By'
+# regex=^Co-Authored-By
+
+# [ignore-by-author-name]
+# Ignore certain rules for commits of which the author name matches a regex
+# E.g. Match commits made by dependabot
+# regex=(.*)dependabot(.*)
+#
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+# ignore=T1,body-min-length
+
+# This is a contrib rule - a community contributed rule. These are disabled by default.
+# You need to explicitly enable them one-by-one by adding them to the "contrib" option
+# under [general] section above.
+# [contrib-title-conventional-commits]
+# Specify allowed commit types. For details see: https://www.conventionalcommits.org/
+# types = bugfix,user-story,epic
+
+[general]
+contrib=contrib-title-conventional-commits
+extra-path=gitlint_rules
+
+[contrib-title-conventional-commits]
+types=fix,feat,perf,doc,ci,style,refactor,chore,build,test

--- a/gitlint_rules/impacts-projects.py
+++ b/gitlint_rules/impacts-projects.py
@@ -1,0 +1,68 @@
+from gitlint.rules import CommitRule, RuleViolation
+import re
+import difflib
+
+PROJECTS = [
+    'lib',
+    'sdk',
+    'validator',
+    'miner',
+    'executor',
+    'facilitator',
+]
+
+class ImpactsProjects(CommitRule):
+    """Enforce that each commit contains an "Impacts:" line with a list
+    of defined projects.
+    """
+
+    name = "body-requires-impacts-footer"
+
+    # A rule MUST have a *unique* id
+    # We recommend starting with UC (for User-defined Commit-rule).
+    id = "UR1"
+
+    regex = re.compile(r'(?im)^\s*impacts:\s*(.*)$')
+
+    def validate(self, commit):
+        # Find all projects listed in any Impacts footer lines
+        full_msg = commit.message.full or ""
+        matches = self.regex.findall(full_msg)
+        projects: list[str] = []
+        for m in matches:
+            for part in m.split(","):
+                name = part.strip()
+                if name:
+                    projects.append(name)
+
+        # If no Impacts header at all, or header without any project names
+        header_present = bool(matches)
+        if not header_present:
+            msg = ("Commit message is missing an 'Impacts:' footer. "
+                   "Add a line like: Impacts: validator, miner")
+            return [RuleViolation(self.id, msg, line_nr=1)]
+
+        if not projects:
+            msg = ("'Impacts:' footer is present but no projects were listed. "
+                   f"Allowed projects: {', '.join(PROJECTS)}")
+            return [RuleViolation(self.id, msg, line_nr=1)]
+
+        # Validate project names
+        allowed = set(PROJECTS)
+        invalid_parts: list[str] = []
+        for p in projects:
+            if p not in allowed:
+                suggestion = difflib.get_close_matches(p, PROJECTS, n=1, cutoff=0.7)
+                if suggestion:
+                    invalid_parts.append(f"{p} (did you mean '{suggestion[0]}'?)")
+                else:
+                    invalid_parts.append(p)
+
+        if invalid_parts:
+            msg = ("Invalid project name(s) in 'Impacts:' footer: "
+                   + ", ".join(invalid_parts)
+                   + ". Allowed projects: " + ", ".join(PROJECTS))
+            return [RuleViolation(self.id, msg, line_nr=1)]
+
+        # All good
+        return []


### PR DESCRIPTION
From now on commit messages will be checked against the rules
defined in the .gitlint file in the repo root.

Impacts: validator,miner,sdk,facilitator,executor,lib
