### PR TITLE
chore: reduce the frequency of sync_collaterals task schedule

### DIFF
--- a/validator/app/src/compute_horde_validator/settings.py
+++ b/validator/app/src/compute_horde_validator/settings.py
@@ -523,9 +523,9 @@ CELERY_BEAT_SCHEDULE = {
     },
     "sync_collaterals": {
         "task": "compute_horde_validator.validator.collateral.tasks.sync_collaterals",
-        "schedule": timedelta(minutes=5),
+        "schedule": timedelta(minutes=10),
         "options": {
-            "expires": timedelta(minutes=5).total_seconds(),
+            "expires": timedelta(minutes=10).total_seconds(),
         },
     },
     "set_scores": {


### PR DESCRIPTION
Recently we are getting subtensor connection errors for 1 out of every 3 tasks:
https://sentry.reef.pl/organizations/reef-technologies/issues/741041/

Impacts: validator