### PR TITLE
chore: Bump pylon service version in the validator runner to 1.1.1

### DIFF
--- a/validator/envs/runner/data/docker-compose.yml
+++ b/validator/envs/runner/data/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       <<: *logging
 
   pylon:
-    image: docker.io/backenddevelopersltd/bittensor-pylon:1.1.0
+    image: docker.io/backenddevelopersltd/bittensor-pylon:1.1.1
     init: true
     restart: unless-stopped
     env_file: ./.env


### PR DESCRIPTION
Updated for introduced fixes with asyncio shield and task retry wait.

Impacts: validator-runner