### PR TITLE
chore: bump pylon to 2.3.1 and pylon client to 2.3.0

### DIFF
--- a/compute_horde/compute_horde/test_base/pylon.py
+++ b/compute_horde/compute_horde/test_base/pylon.py
@@ -1,6 +1,7 @@
 from unittest.mock import create_autospec
 
 import pytest
+from pylon_client._internal.api.abstract_sync import AbstractIdentityApi, AbstractOpenAccessApi
 from pylon_client.v1 import PylonClient
 
 
@@ -8,6 +9,6 @@ from pylon_client.v1 import PylonClient
 def mock_pylon_client():
     mocked = create_autospec(PylonClient)
     mocked.__enter__.return_value = mocked
-    mocked.open_access = create_autospec(PylonClient._open_access_api_cls, instance=True)
-    mocked.identity = create_autospec(PylonClient._identity_api_cls, instance=True)
+    mocked.open_access = create_autospec(AbstractOpenAccessApi, instance=True)
+    mocked.identity = create_autospec(AbstractIdentityApi, instance=True)
     return mocked

--- a/compute_horde/pyproject.toml
+++ b/compute_horde/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "compute-horde-sdk",
     "rich~=13.9.4",
     "web3==7.11.0",
-    "bittensor-pylon-client>=1.7.0,<2.0.0",
+    "bittensor-pylon-client>=2.3.0,<3.0.0",
 ]
 
 [build-system]

--- a/compute_horde/uv.lock
+++ b/compute_horde/uv.lock
@@ -245,19 +245,21 @@ wheels = [
 
 [[package]]
 name = "bittensor-pylon-client"
-version = "1.7.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apscheduler" },
+    { name = "cryptography" },
     { name = "docker" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2f/fe0104d6d2a820172ad6c2108b0add1bfe7dbad0b233ed83d9e8a19be943/bittensor_pylon_client-1.7.0.tar.gz", hash = "sha256:8041413b29e368cfc7edbd19526cfbd5479006da923dc2e7c9628ecc7127e335", size = 24668, upload-time = "2026-02-12T09:58:58.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/10/e5e93f2bda4d0a156f629f1ea82fa91710433bee651cbb4ffa62b36a6716/bittensor_pylon_client-2.3.0.tar.gz", hash = "sha256:1d4ef30e16c55220b87df39bea46946b7e1e420c1d0383c38bf5784ed32257d4", size = 39198, upload-time = "2026-07-09T15:47:57.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/58/029cc473947789d43ede525d0ed6d0bc19f88e5b7146b902ee6d03bbd8b2/bittensor_pylon_client-1.7.0-py3-none-any.whl", hash = "sha256:9b7bf189476204dd9f1fc18d3bfe36f0f63123e1a6ff41f7cd06eae5dc07297a", size = 34744, upload-time = "2026-02-12T09:58:57.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/93/9dfb1824e48137692b55d984833b6d8de155eb6dd607f259e98138c118dd/bittensor_pylon_client-2.3.0-py3-none-any.whl", hash = "sha256:86687e62933d7d982780a83ffd39965d4b9fb32d055de704aeeb6172577309fb", size = 67707, upload-time = "2026-07-09T15:47:56.797Z" },
 ]
 
 [[package]]
@@ -519,7 +521,7 @@ type-check = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = "~=9.9" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", specifier = ">=5.3.0,<6" },
     { name = "compute-horde-sdk", editable = "../compute_horde_sdk" },
     { name = "cryptography", specifier = ">=42.0.8" },

--- a/executor/uv.lock
+++ b/executor/uv.lock
@@ -335,19 +335,21 @@ wheels = [
 
 [[package]]
 name = "bittensor-pylon-client"
-version = "1.7.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apscheduler", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2f/fe0104d6d2a820172ad6c2108b0add1bfe7dbad0b233ed83d9e8a19be943/bittensor_pylon_client-1.7.0.tar.gz", hash = "sha256:8041413b29e368cfc7edbd19526cfbd5479006da923dc2e7c9628ecc7127e335", size = 24668, upload-time = "2026-02-12T09:58:58.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/10/e5e93f2bda4d0a156f629f1ea82fa91710433bee651cbb4ffa62b36a6716/bittensor_pylon_client-2.3.0.tar.gz", hash = "sha256:1d4ef30e16c55220b87df39bea46946b7e1e420c1d0383c38bf5784ed32257d4", size = 39198, upload-time = "2026-07-09T15:47:57.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/58/029cc473947789d43ede525d0ed6d0bc19f88e5b7146b902ee6d03bbd8b2/bittensor_pylon_client-1.7.0-py3-none-any.whl", hash = "sha256:9b7bf189476204dd9f1fc18d3bfe36f0f63123e1a6ff41f7cd06eae5dc07297a", size = 34744, upload-time = "2026-02-12T09:58:57.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/93/9dfb1824e48137692b55d984833b6d8de155eb6dd607f259e98138c118dd/bittensor_pylon_client-2.3.0-py3-none-any.whl", hash = "sha256:86687e62933d7d982780a83ffd39965d4b9fb32d055de704aeeb6172577309fb", size = 67707, upload-time = "2026-07-09T15:47:56.797Z" },
 ]
 
 [[package]]
@@ -584,7 +586,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = "~=9.9" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", specifier = ">=5.3.0,<6" },
     { name = "compute-horde-sdk", editable = "../compute_horde_sdk" },
     { name = "cryptography", specifier = ">=42.0.8" },

--- a/facilitator/devops/tf/main/files/docker-compose.yml
+++ b/facilitator/devops/tf/main/files/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         awslogs-create-group: "true"
 
   pylon:
-    image: docker.io/backenddevelopersltd/bittensor-pylon:1.1.2
+    image: docker.io/backenddevelopersltd/bittensor-pylon:2.3.1
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/facilitator/envs/prod/docker-compose.yml
+++ b/facilitator/envs/prod/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         tag: '{{.Name}}'
 
   pylon:
-    image: docker.io/backenddevelopersltd/bittensor-pylon:1.1.2
+    image: docker.io/backenddevelopersltd/bittensor-pylon:2.3.1
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/facilitator/pyproject.toml
+++ b/facilitator/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pyyaml>=6.0.1",
     "compute-horde",
     "compute-horde-sdk",
-    "bittensor-pylon-client>=1.7.0,<2.0.0",
+    "bittensor-pylon-client>=2.3.0,<3.0.0",
     "PyJWT>=2.10.0,<3.0.0",
     "aiohttp>=3.12.0",
     "kombu[redis]>=5.5.4",

--- a/facilitator/uv.lock
+++ b/facilitator/uv.lock
@@ -348,19 +348,21 @@ wheels = [
 
 [[package]]
 name = "bittensor-pylon-client"
-version = "1.7.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apscheduler", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2f/fe0104d6d2a820172ad6c2108b0add1bfe7dbad0b233ed83d9e8a19be943/bittensor_pylon_client-1.7.0.tar.gz", hash = "sha256:8041413b29e368cfc7edbd19526cfbd5479006da923dc2e7c9628ecc7127e335", size = 24668, upload-time = "2026-02-12T09:58:58.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/10/e5e93f2bda4d0a156f629f1ea82fa91710433bee651cbb4ffa62b36a6716/bittensor_pylon_client-2.3.0.tar.gz", hash = "sha256:1d4ef30e16c55220b87df39bea46946b7e1e420c1d0383c38bf5784ed32257d4", size = 39198, upload-time = "2026-07-09T15:47:57.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/58/029cc473947789d43ede525d0ed6d0bc19f88e5b7146b902ee6d03bbd8b2/bittensor_pylon_client-1.7.0-py3-none-any.whl", hash = "sha256:9b7bf189476204dd9f1fc18d3bfe36f0f63123e1a6ff41f7cd06eae5dc07297a", size = 34744, upload-time = "2026-02-12T09:58:57.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/93/9dfb1824e48137692b55d984833b6d8de155eb6dd607f259e98138c118dd/bittensor_pylon_client-2.3.0-py3-none-any.whl", hash = "sha256:86687e62933d7d982780a83ffd39965d4b9fb32d055de704aeeb6172577309fb", size = 67707, upload-time = "2026-07-09T15:47:56.797Z" },
 ]
 
 [[package]]
@@ -617,7 +619,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = "~=9.9" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", specifier = ">=5.3.0,<6" },
     { name = "compute-horde-sdk", editable = "../compute_horde_sdk" },
     { name = "cryptography", specifier = ">=42.0.8" },
@@ -1353,7 +1355,7 @@ type-check = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = ">=7.2.0" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", extras = ["redis"], specifier = "~=5.3.1" },
     { name = "channels", extras = ["daphne"], specifier = ">=4.0.0" },
     { name = "channels-redis", specifier = ">=4.2.0" },
@@ -2846,7 +2848,7 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:94fc63b3b4bedd327af588696559f68c264440e2503cc9e6954019473d74ae21" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.6.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:94fc63b3b4bedd327af588696559f68c264440e2503cc9e6954019473d74ae21", upload-time = "2025-01-30T00:39:47Z" },
 ]
 
 [[package]]
@@ -2865,8 +2867,8 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:5b6ae523bfb67088a17ca7734d131548a2e60346c622621e4248ed09dd0790cc" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d3dab9fb0294f268aec28e8aaba834e9d006b90a50db5bc2fe2191a9d48c6084" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:5b6ae523bfb67088a17ca7734d131548a2e60346c622621e4248ed09dd0790cc", upload-time = "2025-01-30T00:38:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d3dab9fb0294f268aec28e8aaba834e9d006b90a50db5bc2fe2191a9d48c6084", upload-time = "2025-01-30T00:38:19Z" },
 ]
 
 [[package]]

--- a/local_stack/uv.lock
+++ b/local_stack/uv.lock
@@ -319,19 +319,21 @@ wheels = [
 
 [[package]]
 name = "bittensor-pylon-client"
-version = "1.7.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apscheduler", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2f/fe0104d6d2a820172ad6c2108b0add1bfe7dbad0b233ed83d9e8a19be943/bittensor_pylon_client-1.7.0.tar.gz", hash = "sha256:8041413b29e368cfc7edbd19526cfbd5479006da923dc2e7c9628ecc7127e335", size = 24668, upload-time = "2026-02-12T09:58:58.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/10/e5e93f2bda4d0a156f629f1ea82fa91710433bee651cbb4ffa62b36a6716/bittensor_pylon_client-2.3.0.tar.gz", hash = "sha256:1d4ef30e16c55220b87df39bea46946b7e1e420c1d0383c38bf5784ed32257d4", size = 39198, upload-time = "2026-07-09T15:47:57.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/58/029cc473947789d43ede525d0ed6d0bc19f88e5b7146b902ee6d03bbd8b2/bittensor_pylon_client-1.7.0-py3-none-any.whl", hash = "sha256:9b7bf189476204dd9f1fc18d3bfe36f0f63123e1a6ff41f7cd06eae5dc07297a", size = 34744, upload-time = "2026-02-12T09:58:57.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/93/9dfb1824e48137692b55d984833b6d8de155eb6dd607f259e98138c118dd/bittensor_pylon_client-2.3.0-py3-none-any.whl", hash = "sha256:86687e62933d7d982780a83ffd39965d4b9fb32d055de704aeeb6172577309fb", size = 67707, upload-time = "2026-07-09T15:47:56.797Z" },
 ]
 
 [[package]]
@@ -630,7 +632,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = "~=9.9" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", specifier = ">=5.3.0,<6" },
     { name = "compute-horde-sdk", editable = "../compute_horde_sdk" },
     { name = "cryptography", specifier = ">=42.0.8" },

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       <<: *logging
 
   pylon:
-    image: docker.io/backenddevelopersltd/bittensor-pylon:1.1.2
+    image: docker.io/backenddevelopersltd/bittensor-pylon:2.3.1
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/miner/pyproject.toml
+++ b/miner/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "asyncssh>=2.21.0",
     "kombu[redis]>=5.5.4",
-    "bittensor-pylon-client>=1.7.0,<2.0.0",
+    "bittensor-pylon-client>=2.3.0,<3.0.0",
 ]
 
 [tool.uv.sources]

--- a/miner/uv.lock
+++ b/miner/uv.lock
@@ -348,19 +348,21 @@ wheels = [
 
 [[package]]
 name = "bittensor-pylon-client"
-version = "1.7.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apscheduler", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2f/fe0104d6d2a820172ad6c2108b0add1bfe7dbad0b233ed83d9e8a19be943/bittensor_pylon_client-1.7.0.tar.gz", hash = "sha256:8041413b29e368cfc7edbd19526cfbd5479006da923dc2e7c9628ecc7127e335", size = 24668, upload-time = "2026-02-12T09:58:58.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/10/e5e93f2bda4d0a156f629f1ea82fa91710433bee651cbb4ffa62b36a6716/bittensor_pylon_client-2.3.0.tar.gz", hash = "sha256:1d4ef30e16c55220b87df39bea46946b7e1e420c1d0383c38bf5784ed32257d4", size = 39198, upload-time = "2026-07-09T15:47:57.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/58/029cc473947789d43ede525d0ed6d0bc19f88e5b7146b902ee6d03bbd8b2/bittensor_pylon_client-1.7.0-py3-none-any.whl", hash = "sha256:9b7bf189476204dd9f1fc18d3bfe36f0f63123e1a6ff41f7cd06eae5dc07297a", size = 34744, upload-time = "2026-02-12T09:58:57.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/93/9dfb1824e48137692b55d984833b6d8de155eb6dd607f259e98138c118dd/bittensor_pylon_client-2.3.0-py3-none-any.whl", hash = "sha256:86687e62933d7d982780a83ffd39965d4b9fb32d055de704aeeb6172577309fb", size = 67707, upload-time = "2026-07-09T15:47:56.797Z" },
 ]
 
 [[package]]
@@ -629,7 +631,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = "~=9.9" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", specifier = ">=5.3.0,<6" },
     { name = "compute-horde-sdk", editable = "../compute_horde_sdk" },
     { name = "cryptography", specifier = ">=42.0.8" },
@@ -1559,7 +1561,7 @@ requires-dist = [
     { name = "aiodocker", specifier = ">=0.24.0" },
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "asyncssh", specifier = ">=2.21.0" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", extras = ["redis"], specifier = "~=5.3.1" },
     { name = "channels", extras = ["daphne"], specifier = "==4.*" },
     { name = "channels-redis", specifier = "==4.2.0" },

--- a/validator/app/src/compute_horde_validator/validator/tests/conftest.py
+++ b/validator/app/src/compute_horde_validator/validator/tests/conftest.py
@@ -7,6 +7,7 @@ import bittensor_wallet
 import pytest
 from compute_horde.executor_class import EXECUTOR_CLASS
 from compute_horde_core.executor_class import ExecutorClass
+from pylon_client._internal.api.abstract_sync import AbstractIdentityApi, AbstractOpenAccessApi
 from pylon_client.v1 import PylonClient
 
 from ..organic_jobs.miner_driver import execute_organic_job_request
@@ -102,7 +103,7 @@ def pylon_client_mock(mocker):
     # This is a temporary solution until pylon client implements its own mocking utility.
     mocked = create_autospec(PylonClient)
     mocked.__enter__.return_value = mocked
-    mocked.open_access = create_autospec(PylonClient._open_access_api_cls, instance=True)
-    mocked.identity = create_autospec(PylonClient._identity_api_cls, instance=True)
+    mocked.open_access = create_autospec(AbstractOpenAccessApi, instance=True)
+    mocked.identity = create_autospec(AbstractIdentityApi, instance=True)
     mocker.patch("compute_horde_validator.validator.pylon.PylonClient", return_value=mocked)
     return mocked

--- a/validator/envs/runner/data/docker-compose.yml
+++ b/validator/envs/runner/data/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       <<: *logging
 
   pylon:
-    image: docker.io/backenddevelopersltd/bittensor-pylon:1.1.2
+    image: docker.io/backenddevelopersltd/bittensor-pylon:2.3.1
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/validator/pyproject.toml
+++ b/validator/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "turbobt @ git+https://github.com/bactensor/turbobt.git@close_websocket_transport",
     "aiohttp>=3.12.0",
     "numpy>=2.0",
-    "bittensor-pylon-client>=1.7.0,<2.0.0",
+    "bittensor-pylon-client>=2.3.0,<3.0.0",
 ]
 
 [tool.uv.sources]

--- a/validator/uv.lock
+++ b/validator/uv.lock
@@ -323,19 +323,21 @@ wheels = [
 
 [[package]]
 name = "bittensor-pylon-client"
-version = "1.7.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apscheduler", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2f/fe0104d6d2a820172ad6c2108b0add1bfe7dbad0b233ed83d9e8a19be943/bittensor_pylon_client-1.7.0.tar.gz", hash = "sha256:8041413b29e368cfc7edbd19526cfbd5479006da923dc2e7c9628ecc7127e335", size = 24668, upload-time = "2026-02-12T09:58:58.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/10/e5e93f2bda4d0a156f629f1ea82fa91710433bee651cbb4ffa62b36a6716/bittensor_pylon_client-2.3.0.tar.gz", hash = "sha256:1d4ef30e16c55220b87df39bea46946b7e1e420c1d0383c38bf5784ed32257d4", size = 39198, upload-time = "2026-07-09T15:47:57.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/58/029cc473947789d43ede525d0ed6d0bc19f88e5b7146b902ee6d03bbd8b2/bittensor_pylon_client-1.7.0-py3-none-any.whl", hash = "sha256:9b7bf189476204dd9f1fc18d3bfe36f0f63123e1a6ff41f7cd06eae5dc07297a", size = 34744, upload-time = "2026-02-12T09:58:57.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/93/9dfb1824e48137692b55d984833b6d8de155eb6dd607f259e98138c118dd/bittensor_pylon_client-2.3.0-py3-none-any.whl", hash = "sha256:86687e62933d7d982780a83ffd39965d4b9fb32d055de704aeeb6172577309fb", size = 67707, upload-time = "2026-07-09T15:47:56.797Z" },
 ]
 
 [[package]]
@@ -680,7 +682,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
     { name = "bittensor", specifier = "~=9.9" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "celery", specifier = ">=5.3.0,<6" },
     { name = "compute-horde-sdk", editable = "../compute_horde_sdk" },
     { name = "cryptography", specifier = ">=42.0.8" },
@@ -2826,7 +2828,7 @@ type-check = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.0" },
-    { name = "bittensor-pylon-client", specifier = ">=1.7.0,<2.0.0" },
+    { name = "bittensor-pylon-client", specifier = ">=2.3.0,<3.0.0" },
     { name = "boto3", specifier = ">=1.35.11" },
     { name = "bt-ddos-shield-client", specifier = "~=0.3.3" },
     { name = "celery", extras = ["redis"], specifier = "~=5.3.1" },


### PR DESCRIPTION
## Zmiany

- Obraz `docker.io/backenddevelopersltd/bittensor-pylon`: `1.1.2` → `2.3.1` w:
  - `facilitator/envs/prod/docker-compose.yml`
  - `facilitator/devops/tf/main/files/docker-compose.yml`
  - `validator/envs/runner/data/docker-compose.yml`
  - `miner/envs/runner/data/docker-compose.yml`
- Zależność `bittensor-pylon-client`: `>=1.7.0,<2.0.0` → `>=2.3.0,<3.0.0` w `compute_horde`, `validator`, `miner`, `facilitator` (+ odświeżone `uv.lock`).

Impacts: validator, miner, facilitator