### PR TITLE
fix: replace unmaintained watchtower with nicholas-fedor fork

### DIFF
--- a/install_miner.sh
+++ b/install_miner.sh
@@ -147,7 +147,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:1.20.3
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/install_validator.sh
+++ b/install_validator.sh
@@ -117,7 +117,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:1.20.3
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/miner/envs/runner/README.md
+++ b/miner/envs/runner/README.md
@@ -48,7 +48,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:1.20.3
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/miner/envs/runner/data/docker-compose.yml
+++ b/miner/envs/runner/data/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       "--threshold", "${DOCKER_STORAGE_THRESHOLD:-50 GB}",
       "--keep", "^redis:8.2-alpine",
       "--keep", "^postgres:14.0-alpine",
-      "--keep", "^containrrr/watchtower",
+      "--keep", "^nickfedor/watchtower",
       "--keep", "^stephanmisc/docuum:0.23.1",
       "--keep", "^backenddevelopersltd/compute-horde-miner-runner:v0-latest",
       "--keep", "^backenddevelopersltd/${MINER_IMAGE_REPO}:v0-(latest|preprod)",

--- a/validator/envs/runner/README.md
+++ b/validator/envs/runner/README.md
@@ -32,7 +32,7 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:1.20.3
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Why

The original `containrrr/watchtower` was archived on December 17, 2025. Its embedded Docker API client (v1.25) is rejected by modern Docker engines (Docker 26 dropped old API versions, Docker 29 requires v1.44+), which breaks automatic container updates on hosts running a current Docker.

## What

Replace `containrrr/watchtower:latest` with the actively maintained fork [`nicholas-fedor/watchtower`](https://github.com/nicholas-fedor/watchtower) (image `nickfedor/watchtower`), pinned to `1.20.3`:

- `install_miner.sh` / `install_validator.sh` — compose template written to operators' hosts
- `miner/envs/runner/README.md` / `validator/envs/runner/README.md` — compose snippets in docs
- `miner/envs/runner/data/docker-compose.yml` — docuum `--keep` pattern for the watchtower image

The fork is a drop-in replacement: it keeps the `com.centurylinklabs.watchtower.*` labels and the `--interval`, `--cleanup`, `--label-enable` flags, and supports Docker API v1.43+ with auto-negotiation. Releases are frequent (latest v1.20.3, 2026-08-05).

## Note for existing deployments

The watchtower service lives in the host-side compose file created at install time, so existing miners/validators won't pick this up by pushing new images — operators whose auto-update channel is already broken by a new Docker version need a one-time manual migration (update the image in their `docker-compose.yml` and `docker compose up -d watchtower`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)